### PR TITLE
Replace circle_ci flag by compile_examples

### DIFF
--- a/.github/workflows/general.yml
+++ b/.github/workflows/general.yml
@@ -11,5 +11,5 @@ jobs:
           path: opendihu
       - name: Build 
         working-directory: opendihu
-        run: python3 dependencies/scons/scons.py BUILD_TYPE=RELEASE circle_ci=TRUE
+        run: python3 dependencies/scons/scons.py BUILD_TYPE=RELEASE
 

--- a/SConstructGeneral
+++ b/SConstructGeneral
@@ -83,7 +83,7 @@ vars.Add(EnumVariable('BUILD_TYPE', 'The build type, according to that different
                       allowed_values=('debug', 'release', 'releasewithdebuginfo', 'preprocess', 'assembly'), ignorecase = 2, 
                       map={'d':'debug', 'r':'release', 'rd':'releasewithdebuginfo', 'dr':'releasewithdebuginfo', 'p':'preprocess'}))
 vars.Add(BoolVariable('travis_ci', 'Do not compile and run tests, but compile all examples.', 0))
-vars.Add(BoolVariable('circle_ci', 'Subset of unit tests for circle ci (has limited parallel capabilities.)', 0))
+vars.Add(BoolVariable('compile_examples', 'Compile examples', 0))
 vars.Add(BoolVariable('no_tests', 'Do not compile and run tests.', 0))
 vars.Add(BoolVariable('no_examples', 'Do not compile examples.', 0))
 vars.Add(BoolVariable('gprof', 'Include flags for gprof profiling.', False))
@@ -309,8 +309,7 @@ else:
     if "ZLIB_ROOT" not in os.environ:
       print("ERROR: $ZLIB_ROOT is not set. Did you forget to `module load zlib`?")
     env["CXX"] = os.path.join(opendihu_home, "scripts/fake-scorep.sh")
-  if env["circle_ci"]:
-    env.MergeFlags('-DHAVE_CIRCLE_CI')
+
 
 # flags to always include, except with cray compiler
 if os.environ.get("PE_ENV") != "CRAY" and "pg" not in env["cc"]:

--- a/doc/sphinx/user/installation.rst
+++ b/doc/sphinx/user/installation.rst
@@ -203,8 +203,7 @@ If you like, you can copy the following aliases to your `~/.bashrc` or `~/.bash_
 Then, the following commands can be used for the build:
 
   * ``scons BUILD_TYPE=release`` or ``scons BUILD_TYPE=r`` or ``scons`` or ``s``:
-    Build the file in the current directory in `release` mode, either to be used in the OpenDiHu main directory to build the core library or in any example directory.
-  
+    Build the file in the current directory in `release` mode, either to be used in the OpenDiHu main directory to build the core library or in any example directory. You can optionally build all examples by adding the flag ``compile_examples=TRUE``.
   * ``scons BUILD_TYPE=debug`` or ``scons BUILD_TYPE=d`` or ``sd``: Build `debug` target in current directory.
   * ``sdd``: To be used from within a `build_debug` directory. Go one directory up, build the example in `debug` target and go back to the original directory. This alias is equivalent to ``cd ..; scons BUILD_TYPE=debug; cd -``.
   * ``srr``: To be used from within a `build_release` directory. Go one directory up, build the example in `release` target and go back to the original directory. This alias is equivalent to ``cd ..; scons BUILD_TYPE=release; cd -``.

--- a/testing/unit_testing/SConscript
+++ b/testing/unit_testing/SConscript
@@ -115,10 +115,8 @@ if not env['no_tests']:
     [ -f "SUCCESS6" ] && (echo unit tests on 6 ranks SUCCEDED) || (echo unit tests on 6 ranks FAILED) && \
     (([ ! -f "SUCCESS1" ] || [ ! -f "SUCCESS2" ] || [ ! -f "SUCCESS6" ]) && exit 1) || exit 0')
 
-  if env["BUILD_TYPE"] == "release" and not env["circle_ci"]:
+  if env["BUILD_TYPE"] == "release":
     Depends(test, ['test_examples', 'test1', 'test2', 'test6'])
-  if env["circle_ci"]:
-    Depends(test, ['test1', 'test2'])
   else:
     Depends(test, ['test1', 'test2', 'test6'])
 

--- a/testing/unit_testing/SConscript
+++ b/testing/unit_testing/SConscript
@@ -115,7 +115,7 @@ if not env['no_tests']:
     [ -f "SUCCESS6" ] && (echo unit tests on 6 ranks SUCCEDED) || (echo unit tests on 6 ranks FAILED) && \
     (([ ! -f "SUCCESS1" ] || [ ! -f "SUCCESS2" ] || [ ! -f "SUCCESS6" ]) && exit 1) || exit 0')
 
-  if env["BUILD_TYPE"] == "release":
+  if env["BUILD_TYPE"] == "release" and not ["circle_ci"]:
     Depends(test, ['test_examples', 'test1', 'test2', 'test6'])
   else:
     Depends(test, ['test1', 'test2', 'test6'])

--- a/testing/unit_testing/SConscript
+++ b/testing/unit_testing/SConscript
@@ -92,17 +92,13 @@ if not env['no_tests']:
     program = env.Program('6_ranks_tests', source=src_files)
 
     # add command that runs the tests after build
-    if env["circle_ci"]:
-      test = env.Command(target = 'test6', source = './6_ranks_tests', action = 
-      'cd testing/unit_testing/'+variant_directory+' && mpirun -n 6 --oversubscribe --allow-run-as-root -quiet ./6_ranks_tests || [ -f "SUCCESS6" ]')
-    else:
-      test = env.Command(target = 'test6', source = './6_ranks_tests', action = 
-      'cd testing/unit_testing/'+variant_directory+' && mpirun -n 6 --allow-run-as-root -quiet ./6_ranks_tests || [ -f "SUCCESS6" ]')
+    test = env.Command(target = 'test6', source = './6_ranks_tests', action = 
+      'cd testing/unit_testing/'+variant_directory+' && mpirun -n 6 ---oversubscrive -allow-run-as-root -quiet ./6_ranks_tests || [ -f "SUCCESS6" ]') #Use oversubscribe because of resource limitations in GitHub Actions
 
     AlwaysBuild(test)
 
   # ---- test compilation of examples ----
-  if True and not env["circle_ci"]:
+  if True and env["compile_examples"]:
     # only in release mode
     if env["BUILD_TYPE"] == "release":
       test = env.Command(target = 'test_examples', source = None, action = 'cd scripts && ./check_if_examples_compile.sh')
@@ -115,7 +111,7 @@ if not env['no_tests']:
     [ -f "SUCCESS6" ] && (echo unit tests on 6 ranks SUCCEDED) || (echo unit tests on 6 ranks FAILED) && \
     (([ ! -f "SUCCESS1" ] || [ ! -f "SUCCESS2" ] || [ ! -f "SUCCESS6" ]) && exit 1) || exit 0')
 
-  if env["BUILD_TYPE"] == "release" and not ["circle_ci"]:
+  if env["BUILD_TYPE"] == "release" and env["compile_examples"]:
     Depends(test, ['test_examples', 'test1', 'test2', 'test6'])
   else:
     Depends(test, ['test1', 'test2', 'test6'])

--- a/testing/unit_testing/SConscript
+++ b/testing/unit_testing/SConscript
@@ -93,7 +93,7 @@ if not env['no_tests']:
 
     # add command that runs the tests after build
     test = env.Command(target = 'test6', source = './6_ranks_tests', action = 
-      'cd testing/unit_testing/'+variant_directory+' && mpirun -n 6 ---oversubscrive -allow-run-as-root -quiet ./6_ranks_tests || [ -f "SUCCESS6" ]') #Use oversubscribe because of resource limitations in GitHub Actions
+      'cd testing/unit_testing/'+variant_directory+' && mpirun -n 6 --oversubscribe -allow-run-as-root -quiet ./6_ranks_tests || [ -f "SUCCESS6" ]') #Use oversubscribe because of resource limitations in GitHub Actions
 
     AlwaysBuild(test)
 

--- a/testing/unit_testing/src/6_ranks/partitioned_petsc_vec.cpp
+++ b/testing/unit_testing/src/6_ranks/partitioned_petsc_vec.cpp
@@ -11,8 +11,6 @@
 #include "partition/partitioned_petsc_vec/01_partitioned_petsc_vec_with_dirichlet_bc.h"
 #include "spatial_discretization/dirichlet_boundary_conditions/01_dirichlet_boundary_conditions.h"
 
-// this test case usually works, but not on the circle ci testcase
-#ifndef HAVE_CIRCLE_CI
 TEST(PartitionedPetscVecTest, Test)
 {
   // explicit functionSpace with node positions
@@ -211,5 +209,3 @@ config = {
 
   nFails += ::testing::Test::HasFailure();
 }
-
-#endif


### PR DESCRIPTION
- The `circle_ci` flag has been removed, since all test are now able to run in the CI workflow. 
- A new `compile_examples` flag has been introduced, so that the user and the CI workflow can select unit test without the compilation of the examples, which takes much longer.