### PR TITLE
Include mechanics test in unit_tests

### DIFF
--- a/testing/unit_testing/SConscript
+++ b/testing/unit_testing/SConscript
@@ -63,7 +63,7 @@ if not env['no_tests']:
                  'src/2_ranks/diffusion.cpp',
                  'src/2_ranks/poisson.cpp',
                  'src/2_ranks/neumann_boundary_conditions.cpp',
-                 # 'src/2_rank/solid_mechanics.cpp',
+                 'src/2_ranks/solid_mechanics.cpp',
                  'src/2_ranks/main.cpp',
                  'src/utility.cpp',
                  'src/2_ranks/partitioned_petsc_vec.cpp',

--- a/testing/unit_testing/SConscript
+++ b/testing/unit_testing/SConscript
@@ -36,7 +36,7 @@ if not env['no_tests']:
                 'src/1_rank/operator_splitting.cpp',
                 'src/1_rank/output.cpp',
                 'src/1_rank/poisson.cpp',
-                # 'src/1_rank/solid_mechanics.cpp',
+                'src/1_rank/solid_mechanics.cpp',
                 'src/1_rank/unstructured_deformable.cpp',
                 'src/1_rank/composite_mesh.cpp',
                 'src/utility.cpp']


### PR DESCRIPTION
Mechanics tests were not compiling, but as it turns out, it was only due to a typo on the path. 