### PR TITLE
Use flag no_examples instead of compile_examples

### DIFF
--- a/.github/workflows/general.yml
+++ b/.github/workflows/general.yml
@@ -11,5 +11,5 @@ jobs:
           path: opendihu
       - name: Build 
         working-directory: opendihu
-        run: python3 dependencies/scons/scons.py BUILD_TYPE=RELEASE
+        run: python3 dependencies/scons/scons.py BUILD_TYPE=RELEASE no_examples = TRUE
 

--- a/.github/workflows/general.yml
+++ b/.github/workflows/general.yml
@@ -11,5 +11,5 @@ jobs:
           path: opendihu
       - name: Build 
         working-directory: opendihu
-        run: python3 dependencies/scons/scons.py BUILD_TYPE=RELEASE no_examples = TRUE
+        run: python3 dependencies/scons/scons.py BUILD_TYPE=RELEASE no_examples=TRUE
 

--- a/SConstructGeneral
+++ b/SConstructGeneral
@@ -83,7 +83,6 @@ vars.Add(EnumVariable('BUILD_TYPE', 'The build type, according to that different
                       allowed_values=('debug', 'release', 'releasewithdebuginfo', 'preprocess', 'assembly'), ignorecase = 2, 
                       map={'d':'debug', 'r':'release', 'rd':'releasewithdebuginfo', 'dr':'releasewithdebuginfo', 'p':'preprocess'}))
 vars.Add(BoolVariable('travis_ci', 'Do not compile and run tests, but compile all examples.', 0))
-vars.Add(BoolVariable('compile_examples', 'Compile examples', 0))
 vars.Add(BoolVariable('no_tests', 'Do not compile and run tests.', 0))
 vars.Add(BoolVariable('no_examples', 'Do not compile examples.', 0))
 vars.Add(BoolVariable('gprof', 'Include flags for gprof profiling.', False))

--- a/doc/sphinx/user/installation.rst
+++ b/doc/sphinx/user/installation.rst
@@ -203,7 +203,7 @@ If you like, you can copy the following aliases to your `~/.bashrc` or `~/.bash_
 Then, the following commands can be used for the build:
 
   * ``scons BUILD_TYPE=release`` or ``scons BUILD_TYPE=r`` or ``scons`` or ``s``:
-    Build the file in the current directory in `release` mode, either to be used in the OpenDiHu main directory to build the core library or in any example directory. You can optionally build all examples by adding the flag ``compile_examples=TRUE``.
+    Build the file in the current directory in `release` mode, either to be used in the OpenDiHu main directory to build the core library or in any example directory. You can optionally add the flags ``no_examples=TRUE`` and/or ``no_tests=TRUE``.
   * ``scons BUILD_TYPE=debug`` or ``scons BUILD_TYPE=d`` or ``sd``: Build `debug` target in current directory.
   * ``sdd``: To be used from within a `build_debug` directory. Go one directory up, build the example in `debug` target and go back to the original directory. This alias is equivalent to ``cd ..; scons BUILD_TYPE=debug; cd -``.
   * ``srr``: To be used from within a `build_release` directory. Go one directory up, build the example in `release` target and go back to the original directory. This alias is equivalent to ``cd ..; scons BUILD_TYPE=release; cd -``.

--- a/testing/unit_testing/SConscript
+++ b/testing/unit_testing/SConscript
@@ -98,7 +98,7 @@ if not env['no_tests']:
     AlwaysBuild(test)
 
   # ---- test compilation of examples ----
-  if True and env["compile_examples"]:
+  if True and not env["no_examples"]:
     # only in release mode
     if env["BUILD_TYPE"] == "release":
       test = env.Command(target = 'test_examples', source = None, action = 'cd scripts && ./check_if_examples_compile.sh')
@@ -111,7 +111,7 @@ if not env['no_tests']:
     [ -f "SUCCESS6" ] && (echo unit tests on 6 ranks SUCCEDED) || (echo unit tests on 6 ranks FAILED) && \
     (([ ! -f "SUCCESS1" ] || [ ! -f "SUCCESS2" ] || [ ! -f "SUCCESS6" ]) && exit 1) || exit 0')
 
-  if env["BUILD_TYPE"] == "release" and env["compile_examples"]:
+  if env["BUILD_TYPE"] == "release" and not env["no_examples"]:
     Depends(test, ['test_examples', 'test1', 'test2', 'test6'])
   else:
     Depends(test, ['test1', 'test2', 'test6'])

--- a/testing/unit_testing/SConscript
+++ b/testing/unit_testing/SConscript
@@ -111,10 +111,10 @@ if not env['no_tests']:
     [ -f "SUCCESS6" ] && (echo unit tests on 6 ranks SUCCEDED) || (echo unit tests on 6 ranks FAILED) && \
     (([ ! -f "SUCCESS1" ] || [ ! -f "SUCCESS2" ] || [ ! -f "SUCCESS6" ]) && exit 1) || exit 0')
 
-  if env["BUILD_TYPE"] == "release" and not env["no_examples"]:
-    Depends(test, ['test_examples', 'test1', 'test2', 'test6'])
-  else:
+  if env["no_examples"]:
     Depends(test, ['test1', 'test2', 'test6'])
+  else:
+    Depends(test, ['test_examples', 'test1', 'test2', 'test6'])
 
 if env['travis_ci']:
   test = env.Command(target = 'test_examples', source = None, action = 'cd scripts && ./check_if_examples_compile.sh')


### PR DESCRIPTION
Avoid having duplicated flags for whether we compile examples. 
I choose to keep no_examples, because no_tests already exists. 