### PR TITLE
fix: gitignore std_simd

### DIFF
--- a/dependencies/.gitignore
+++ b/dependencies/.gitignore
@@ -38,3 +38,4 @@ xercesc
 xsd
 boost
 precice
+std_simd


### PR DESCRIPTION
## Main changes of this PR

- found this commit in my worktree, currently std_simd is not gitignored

## Additional information


## Author's checklist

* [x] I updated the documentation.
* [x] I used clang-formating.


