### PR TITLE
doc: fix two typos

### DIFF
--- a/doc/sphinx/user/framework_structure.rst
+++ b/doc/sphinx/user/framework_structure.rst
@@ -9,7 +9,7 @@ Usage
 To use the framework, one needs to use two programming languages: C++ and Python.
 For a simulation, one has to write a small C++ `main` file that includes the main framework header (`opendihu.h`) and contains a definition of the desired nested solvers as class templates.
 
-This source file will be compiled either in debug or release mode. It will be linked against a single opendihu library under `core/build_debug/libopendihud.a` or `core/build_debug/libopendihu.a`.
+This source file will be compiled either in debug or release mode. It will be linked against a single opendihu library under `core/build_debug/libopendihud.a` or `core/build_release/libopendihu.a`.
 For example, you can build any example in its top-level directory by calling 
 
 .. code-block:: bash

--- a/doc/sphinx/user/getting_started.rst
+++ b/doc/sphinx/user/getting_started.rst
@@ -21,7 +21,7 @@ Getting started
   .. code-block:: bash
 
     cd build_release
-    ./laplace_regular settings_lagrange_quadratic.py
+    ./laplace_regular ../settings_lagrange_quadratic.py
 
 * Output files in this example (and likewise in the other examples) will be created under the `out` subdirectory. 
   If you look into `out`, you'll find two files: `laplace.py` and `laplace.vtr`.


### PR DESCRIPTION
## Main changes of this PR

also found this in my worktree, fixes two typos regarding running the example


## Additional information

<!--
List known related issues, upcomming work, etc. 
-->

## Author's checklist

* [x] I updated the documentation.
* [x] I used clang-formating.


