### PR TITLE
fix: broken paths in example build scripts or variable definition

### DIFF
--- a/examples/electrophysiology/fibers/fibers_contraction/no_precice/biceps/SConstruct
+++ b/examples/electrophysiology/fibers/fibers_contraction/no_precice/biceps/SConstruct
@@ -8,11 +8,11 @@
 import os
 
 # get the directory where opendihu is installed (the top level directory of opendihu)
-opendihu_home = os.environ.get('OPENDIHU_HOME') or "../../../../.."
+opendihu_home = os.environ.get('OPENDIHU_HOME') or "../../../../../../"
 
 # set path where the "SConscript" file is located (set to current path)
 path_where_to_call_sconscript = Dir('.').srcnode().abspath
 
 # call general SConstruct that will configure everything and then call SConscript at the given path
-SConscript(os.path.join(opendihu_home,'SConstructGeneral'), 
+SConscript(os.path.join(opendihu_home,'SConstructGeneral'),
            exports={"path": path_where_to_call_sconscript})

--- a/examples/electrophysiology/fibers/fibers_contraction/no_precice/cuboid_muscle/SConstruct
+++ b/examples/electrophysiology/fibers/fibers_contraction/no_precice/cuboid_muscle/SConstruct
@@ -8,11 +8,11 @@
 import os
 
 # get the directory where opendihu is installed (the top level directory of opendihu)
-opendihu_home = os.environ.get('OPENDIHU_HOME') or "../../.."
+opendihu_home = os.environ.get('OPENDIHU_HOME') or "../../../../../../"
 
 # set path where the "SConscript" file is located (set to current path)
 path_where_to_call_sconscript = Dir('.').srcnode().abspath
 
 # call general SConstruct that will configure everything and then call SConscript at the given path
-SConscript(os.path.join(opendihu_home,'SConstructGeneral'), 
+SConscript(os.path.join(opendihu_home,'SConstructGeneral'),
            exports={"path": path_where_to_call_sconscript})

--- a/examples/electrophysiology/fibers/fibers_contraction/no_precice/cuboid_muscle/variables/variables.py
+++ b/examples/electrophysiology/fibers/fibers_contraction/no_precice/cuboid_muscle/variables/variables.py
@@ -77,7 +77,7 @@ for x in range(el_x):
 
 # Define directory for cellml files
 import os
-input_dir = os.path.join(os.environ.get('OPENDIHU_HOME', '../../../../../'), "examples/electrophysiology/input/")
+input_dir = os.path.join(os.environ.get('OPENDIHU_HOME', '../../../../../../../'), "examples/electrophysiology/input/")
 
 # Fiber activation
 fiber_distribution_file = input_dir + "MU_fibre_distribution_3780.txt"

--- a/examples/solid_mechanics/dynamic_mooney_rivlin/muscle_with_fat/SConstruct
+++ b/examples/solid_mechanics/dynamic_mooney_rivlin/muscle_with_fat/SConstruct
@@ -8,11 +8,11 @@
 import os
 
 # get the directory where opendihu is installed (the top level directory of opendihu)
-opendihu_home = os.environ.get('OPENDIHU_HOME') or "../../.."
+opendihu_home = os.environ.get('OPENDIHU_HOME') or "../../../.."
 
 # set path where the "SConscript" file is located (set to current path)
 path_where_to_call_sconscript = Dir('.').srcnode().abspath
 
 # call general SConstruct that will configure everything and then call SConscript at the given path
-SConscript(os.path.join(opendihu_home,'SConstructGeneral'), 
+SConscript(os.path.join(opendihu_home,'SConstructGeneral'),
            exports={"path": path_where_to_call_sconscript})


### PR DESCRIPTION
## Main changes of this PR

Found a couple of examples with had broken paths, if `OPENDIHU_HOME` wasnt used. Had this lying around for quite some time


## Additional information

<!--
List known related issues, upcomming work, etc. 
-->

## Author's checklist

* [x] I updated the documentation.
* [x] I used clang-formating.


