### PR TITLE
Update docker

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -3,7 +3,7 @@ on: [push, pull_request]
 jobs:
   container-test-job:
     runs-on: ubuntu-latest
-    container: maierbn/opendihu:latest
+    container: carmehp/opendihu:latest
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -8,7 +8,7 @@ jobs:
       - name: Checkout and rebuild
         run: |
           cd /workspace/opendihu
-          {{ github.event.pull_request.head.sha }
+          git pull {{ github.ref }
           echo "Show git status:"
           git status
           python3 dependencies/scons/scons.py BUILD_TYPE=RELEASE no_examples=TRUE

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -3,7 +3,7 @@ on: [push, pull_request]
 jobs:
   container-test-job:
     runs-on: ubuntu-latest
-    container: carmehp/opendihu:ci
+    container: carmehp/opendihu-ci
     steps:
       - name: Checkout and rebuild
         run: |

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -8,7 +8,7 @@ jobs:
       - name: Checkout and rebuild
         run: |
           cd /workspace/opendihu
-          git pull origin ${{ github.ref_name }}
+          git pull origin ${{ github.event.pull_request.head.sha }}
           echo "Show git status:"
           git status
           python3 dependencies/scons/scons.py BUILD_TYPE=RELEASE no_examples=TRUE

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -5,12 +5,10 @@ jobs:
     runs-on: ubuntu-latest
     container: carmehp/opendihu:latest
     steps:
-      - name: Get code
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 2
-      - name: Checkout head
-        run: git checkout HEAD^
+      - name: Show path
+        run: pwd
+      - name: Show content
+        run: ls
       - name: Build 
         working-directory: opendihu
         run: python3 dependencies/scons/scons.py BUILD_TYPE=RELEASE no_examples=TRUE

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -5,10 +5,14 @@ jobs:
     runs-on: ubuntu-latest
     container: carmehp/opendihu:latest
     steps:
+      - name: Go to directory
+        run: cd /workspace/opendihu
       - name: Show path
         run: pwd
-      - name: Show content
-        run: ls
+      - name: List Files in Root Directory
+        run: |
+          echo "Listing files in the root directory:"
+          ls -lah
       - name: Build 
         working-directory: opendihu
         run: python3 dependencies/scons/scons.py BUILD_TYPE=RELEASE no_examples=TRUE

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -6,14 +6,10 @@ jobs:
     container: carmehp/opendihu:latest
     steps:
       - name: Go to directory
-        run: cd /workspace/opendihu
-      - name: Show path
-        run: pwd
-      - name: List Files in Root Directory
         run: |
+          cd /workspace/opendihu
+          pwd
           echo "Listing files in the root directory:"
           ls -lah
-      - name: Build 
-        working-directory: opendihu
-        run: python3 dependencies/scons/scons.py BUILD_TYPE=RELEASE no_examples=TRUE
+          python3 dependencies/scons/scons.py BUILD_TYPE=RELEASE no_examples=TRUE
 

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -5,10 +5,11 @@ jobs:
     runs-on: ubuntu-latest
     container: carmehp/opendihu:latest
     steps:
-      - name: Checkout repository
-        uses: actions/checkout@v3
+      - name: Get code
+      uses: actions/checkout@v4
         with:
-          path: opendihu
+          fetch-depth: 2
+      run: git checkout HEAD^
       - name: Build 
         working-directory: opendihu
         run: python3 dependencies/scons/scons.py BUILD_TYPE=RELEASE no_examples=TRUE

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -5,11 +5,11 @@ jobs:
     runs-on: ubuntu-latest
     container: carmehp/opendihu:latest
     steps:
-      - name: Go to directory
+      - name: Checkout and rebuild
         run: |
           cd /workspace/opendihu
-          pwd
-          echo "Listing files in the root directory:"
-          ls -lah
+          {{ github.event.pull_request.head.sha }
+          echo "Show git status:"
+          git status
           python3 dependencies/scons/scons.py BUILD_TYPE=RELEASE no_examples=TRUE
 

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -3,13 +3,11 @@ on: [push, pull_request]
 jobs:
   container-test-job:
     runs-on: ubuntu-latest
-    container: carmehp/opendihu:latest
+    container: carmehp/opendihu:ci
     steps:
       - name: Checkout and rebuild
         run: |
           cd /workspace/opendihu
           git pull origin ${{ github.event.pull_request.head.sha }}
-          echo "Show git status:"
-          git status
           python3 dependencies/scons/scons.py BUILD_TYPE=RELEASE no_examples=TRUE
 

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -8,7 +8,7 @@ jobs:
       - name: Checkout and rebuild
         run: |
           cd /workspace/opendihu
-          git pull {{ github.ref }
+          git pull origin ${{ github.ref_name }}
           echo "Show git status:"
           git status
           python3 dependencies/scons/scons.py BUILD_TYPE=RELEASE no_examples=TRUE

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -7,8 +7,10 @@ jobs:
     steps:
       - name: Show path
         run: pwd
-      - name: Show content
-        run: ls
+      - name: List Files in Root Directory
+        run: |
+          echo "Listing files in the root directory:"
+          ls -lah
       - name: Build 
         working-directory: opendihu
         run: python3 dependencies/scons/scons.py BUILD_TYPE=RELEASE no_examples=TRUE

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -6,10 +6,11 @@ jobs:
     container: carmehp/opendihu:latest
     steps:
       - name: Get code
-      uses: actions/checkout@v4
+        uses: actions/checkout@v4
         with:
           fetch-depth: 2
-      run: git checkout HEAD^
+      - name: Checkout head
+        run: git checkout HEAD^
       - name: Build 
         working-directory: opendihu
         run: python3 dependencies/scons/scons.py BUILD_TYPE=RELEASE no_examples=TRUE

--- a/SConstructGeneral
+++ b/SConstructGeneral
@@ -55,7 +55,9 @@ sconsconfig.select(
     packages.ADIOS(required=False),    # ADIOS, a library that handles efficient and parallel data output
     #packages.MegaMol(required=False),  # Adds the MegaMol visualization framework
     #packages.VTK(required=False),     # VTK, needed only for chaste
-    #packages.HDF5(required=False),    # The parallel output library HDF5, compiled with --enable-parallel as needed for chaste, the version that Petsc can download does not have this feature
+    packages.HDF5(required=True),    # The parallel output library HDF5, compiled with --enable-parallel as needed for chaste, the version that Petsc can download does not have this feature
+    packages.NlohmannJson(required=True),
+    packages.SCR(required=True),
     #packages.XercesC(required=False), # XML-parser, needed for chaste
     #packages.xsd(required=False),     # XML Schema to C++ data binding compiler, needed for chaste
     #packages.boost(required=False),   # boost C++ library, needed for chaste

--- a/dependencies/.gitignore
+++ b/dependencies/.gitignore
@@ -39,3 +39,5 @@ xsd
 boost
 precice
 std_simd
+scr
+nlohmannjson

--- a/dependencies/scons-config/sconsconfig/packages/HDF5.py
+++ b/dependencies/scons-config/sconsconfig/packages/HDF5.py
@@ -6,15 +6,12 @@ class HDF5(Package):
 
     def __init__(self, **kwargs):
         defaults = {
-            'download_url': 'https://support.hdfgroup.org/ftp/HDF5/releases/hdf5-1.10/hdf5-1.10.5/src/hdf5-1.10.5.tar.gz',
+            'download_url': 'https://support.hdfgroup.org/ftp/HDF5/releases/hdf5-1.14/hdf5-1.14.4/src/hdf5-1.14.4-3.tar.gz',
         }
         defaults.update(kwargs)
         super(HDF5, self).__init__(**defaults)
         self.parallel = kwargs.get('parallel', True)
-        self.libs=[
-            {'libraries': 'hdf5', 'prepend': False},
-            'hdf5',
-        ]
+        self.libs=['hdf5']
         self.extra_libs=[
             [], ['z'], ['m'], ['z', 'm'],
         ]
@@ -24,30 +21,38 @@ class HDF5(Package):
 #include <stdio.h>
 #include <hdf5.h>
 #include <mpi.h>
+
+#define FILE "testfile.h5"
+
 int main(int argc, char* argv[]) {
-   hid_t plist_id, file_id, mem_space, file_space, dset_id;
-   hsize_t dims[1];
-   int data[10];
-   int rank;
-   MPI_Info info = MPI_INFO_NULL;
-   MPI_Init(&argc, &argv);
-   MPI_Comm_rank(MPI_COMM_WORLD, &rank);
-   plist_id = H5Pcreate(H5P_FILE_ACCESS);
-   H5Pset_fapl_mpio(plist_id, MPI_COMM_WORLD, info);
-   file_id = H5Fcreate("testfile", H5F_ACC_TRUNC, H5P_DEFAULT, plist_id);
-   H5Pclose(plist_id);
-   dims[0] = 10;
-   mem_space = H5Screate_simple(1, dims, NULL);
-   file_space = H5Screate_simple(1, dims, NULL);
-   dset_id = H5Dcreate1(file_id, "test", H5T_NATIVE_INT, file_space, H5P_DEFAULT);
-   H5Sselect_all(mem_space);
-   H5Sselect_all(file_space);
-   plist_id = H5Pcreate(H5P_DATASET_XFER);
-   H5Pset_dxpl_mpio(plist_id, H5FD_MPIO_COLLECTIVE);
-   H5Dwrite(dset_id, H5T_NATIVE_INT, mem_space, file_space, plist_id, data);
-   H5Fclose(file_id);
-   MPI_Finalize();
-   return EXIT_SUCCESS;
+  hid_t plist_id, file_id, mem_space, file_space, dset_id;
+  hsize_t dims[1];
+  dims[0] = 10;
+  int data[10];
+  int rank;
+
+  MPI_Init(&argc, &argv);
+  MPI_Comm_rank(MPI_COMM_WORLD, &rank);
+
+  plist_id = H5Pcreate(H5P_FILE_ACCESS);
+  H5Pset_fapl_mpio(plist_id, MPI_COMM_WORLD, MPI_INFO_NULL);
+  file_id = H5Fcreate(FILE, H5F_ACC_TRUNC, H5P_DEFAULT, plist_id);
+  H5Pclose(plist_id);
+
+  file_space = H5Screate_simple(1, dims, NULL);
+  dset_id = H5Dcreate(file_id, "test", H5T_NATIVE_INT, file_space, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT);
+  plist_id = H5Pcreate(H5P_DATASET_XFER);
+  H5Pset_dxpl_mpio(plist_id, H5FD_MPIO_COLLECTIVE);
+  H5Dwrite(dset_id, H5T_NATIVE_INT, H5P_DEFAULT, file_space, plist_id, data);
+
+  H5Pclose(plist_id);
+  H5Dclose(dset_id);
+  H5Sclose(file_space);
+  H5Fclose(file_id);
+  MPI_Finalize();
+
+  remove(FILE);
+  return EXIT_SUCCESS;
 }
 '''
         else:
@@ -64,14 +69,19 @@ int main(int argc, char* argv[]) {
 }
 '''
 
-        # For the same reasons as MPI, disable running.
-        self.run = False
-
         # Setup the build handler. I'm going to assume this will work for all architectures.
         self.set_build_handler([
-            './configure --prefix=${PREFIX} --enable-shared --enable-parallel',
-            'make',
-            'make install'
+            "mkdir -p ${PREFIX}",
+            "cd ${SOURCE_DIR} && \
+            mkdir -pv build && cd build && \
+            cmake -DCMAKE_BUILD_TYPE=RELEASE \
+                  -DHDF5_BUILD_CPP_LIB=OFF \
+                  -DHDF5_ENABLE_PARALLEL=ON \
+                  -DBUILD_SHARED_LIBS=ON \
+                  -DCMAKE_INSTALL_PREFIX=${PREFIX} \
+                  CC=mpicc \
+                  .. && \
+            make && make install",
         ])
 
     def check(self, ctx):

--- a/dependencies/scons-config/sconsconfig/packages/__init__.py
+++ b/dependencies/scons-config/sconsconfig/packages/__init__.py
@@ -2,6 +2,7 @@ from .clock import clock
 from .MPI import MPI
 from .GSL import GSL
 from .HDF5 import HDF5
+from .nlohmannjson import NlohmannJson
 from .FFTW import FFTW
 from .FFTW3 import FFTW3
 from .PETSc import PETSc
@@ -58,3 +59,4 @@ from .xbraid import xbraid
 from .opencor import OpenCOR
 from .precice import precice
 from .std_simd import std_simd
+from .scr import SCR

--- a/dependencies/scons-config/sconsconfig/packages/nlohmannjson.py
+++ b/dependencies/scons-config/sconsconfig/packages/nlohmannjson.py
@@ -1,0 +1,82 @@
+from .Package import Package
+
+example = r"""
+#include <iostream>
+#include <iomanip>
+#include <nlohmann/json.hpp>
+
+using json = nlohmann::json;
+
+int main()
+{
+  // create a JSON object
+  json j =
+  {
+    {"pi", 3.141},
+    {"happy", true},
+    {"name", "Niels"},
+    {"nothing", nullptr},
+    {
+      "answer", {
+        {"everything", 42}
+      }
+    },
+    {"list", {1, 0, 2}},
+    {
+      "object", {
+         {"currency", "USD"},
+         {"value", 42.99}
+      }
+    }
+  };
+
+  // add new values
+  j["new"]["key"]["value"] = {"another", "list"};
+
+  // count elements
+  auto s = j.size();
+  j["size"] = s;
+
+  // pretty print with indent of 4 spaces
+  std::cout << std::setw(4) << j << '\n';
+}
+"""
+
+
+class NlohmannJson(Package):
+    def __init__(self, **kwargs):
+        defaults = {
+            "download_url": "https://github.com/nlohmann/json/archive/refs/tags/v3.11.3.tar.gz"
+        }
+        defaults.update(kwargs)
+        super(NlohmannJson, self).__init__(**defaults)
+        self.sub_dirs = [
+            ("", ""),
+            ("include","")
+        ]
+        self.ext = '.cpp'
+
+        self.check_text = example
+        self.static = False
+        self.number_output_lines = 11540 * 1.45
+
+    def check(self, ctx):
+        env = ctx.env
+        ctx.Message("Checking for NlohmannJson ...  ")
+
+        self.set_build_handler(
+            [
+                "mkdir -p ${PREFIX}",
+                "cd ${SOURCE_DIR} && \
+                 mkdir -pv build && cd build && \
+                 cmake -DCMAKE_BUILD_TYPE=RELEASE -DCMAKE_INSTALL_PREFIX=${PREFIX} .. && \
+                 make -j && make install",
+            ]
+        )
+
+        self.check_options(env)
+        res = super(NlohmannJson, self).check(ctx)
+
+        self.check_required(res[0], ctx)
+        ctx.Result(res[0])
+        return res[0]

--- a/dependencies/scons-config/sconsconfig/packages/scr.py
+++ b/dependencies/scons-config/sconsconfig/packages/scr.py
@@ -1,0 +1,89 @@
+from .Package import Package
+
+scr_text = r"""
+#include <stdio.h>
+#include <string.h>
+#include <unistd.h>
+#include <sys/types.h>
+#include <assert.h>
+#include <stdlib.h>
+#include <iostream>
+#include "mpi.h"
+#include "scr.h"
+int checkpoint(int size_mb) {
+  int rank;
+  char tmp[256];
+  char file[SCR_MAX_FILENAME];
+  char dir[SCR_MAX_FILENAME];
+  char dname;
+  int rc;
+  MPI_Comm_rank(MPI_COMM_WORLD, &rank);
+  SCR_Start_checkpoint();
+  sprintf(tmp, "rank_%d", rank);
+  std::cout << "In: " << tmp << "\n";
+  SCR_Route_file(tmp, file);
+  std::cout << "Out: " << file << "\n";
+  SCR_Complete_checkpoint(1);
+  return 0;
+}
+int main(int argc, char **argv) {
+  int size_mb = 1;
+  MPI_Init(NULL, NULL);
+  SCR_Configf("SCR_CHECKPOINT_INTERVAL=%d", 1);
+  SCR_Configf("SCR_USER_NAME=%s", "scons");
+  SCR_Init();
+  int flag = 0;
+  SCR_Need_checkpoint(&flag);
+  if (flag) {
+    checkpoint(size_mb);
+  }
+  SCR_Finalize();
+  MPI_Finalize();
+  return 0;
+}
+"""
+
+
+class SCR(Package):
+    def __init__(self, **kwargs):
+        defaults = {
+            "download_url": "https://github.com/LLNL/scr/archive/refs/tags/v3.0.1.tar.gz"
+        }
+        defaults.update(kwargs)
+        super(SCR, self).__init__(**defaults)
+        self.sub_dirs = [
+            # could be either lib or lib64
+            ("include", "lib"),
+            ("include", "lib64")
+        ]
+        self.libs = ["scr"]
+        self.headers = ["scr.h"]
+
+        self.ext = '.cpp'
+        self.check_text = scr_text
+        self.static = False
+        self.number_output_lines = 11540 * 1.45
+
+    def check(self, ctx):
+        env = ctx.env
+        ctx.Message("Checking for SCR ...           ")
+
+        self.set_build_handler(
+            [
+                "mkdir -p ${PREFIX}",
+                "sed -i 's/#!\\/bin\\/bash/#!\\/usr\\/bin\\/env bash/g' ${SOURCE_DIR}/bootstrap.sh",
+                "sed -i '/INSTALL_DIR=/d' ${SOURCE_DIR}/bootstrap.sh",
+                "cd ${SOURCE_DIR} && \
+                 INSTALL_DIR=${PREFIX} ./bootstrap.sh --tag && \
+                 mkdir -pv build && cd build && \
+                 cmake -DCMAKE_BUILD_TYPE=RELEASE -DCMAKE_INSTALL_PREFIX=${PREFIX} .. && \
+                 make && make install",
+            ]
+        )
+
+        self.check_options(env)
+        res = super(SCR, self).check(ctx)
+
+        self.check_required(res[0], ctx)
+        ctx.Result(res[0])
+        return res[0]

--- a/doc/sphinx/user/installation.rst
+++ b/doc/sphinx/user/installation.rst
@@ -15,7 +15,7 @@ Using docker
 With the docker image, you can use the framework directly without having to build and install any dependencies. Parallel execution with MPI is possible.
 The disadvantage is that you only have a shell and can't plot anything. However, you may copy the files from the docker container to your machine (or directly mount the respective directory) and do the plotting there. 
 
-You can either download a pre-built image or building the container from source using one of the available `Dockerfile`s. 
+You can either download a pre-built image or build an image from source using one of the available `Dockerfile`. 
 In either case, you will have to install Docker first. For that we refer you to the official `docker installation instructions <https://docs.docker.com/engine/install/>`_ .
 
 * Using the pre-built docker image

--- a/doc/sphinx/user/installation.rst
+++ b/doc/sphinx/user/installation.rst
@@ -13,36 +13,37 @@ The docker image serves all the available functionality for executing simulation
 Using docker
 ----------------
 With the docker image, you can use the framework directly without having to build and install any dependencies. Parallel execution with MPI is possible.
-The disadvantage is that you only have a shell and can't plot anything. 
-We provide docker images on docker hub that contain the latest release as of November 2023. They are based on recent Ubuntu 22.04 as well as legacy Ubuntu 16.04 to 20.04:
+The disadvantage is that you only have a shell and can't plot anything. However, you may copy the files from the docker container to your machine and do the plotting there. 
 
-* ``maierbn/opendihu:2204`` or alias ``maierbn/opendihu:latest``: 
+You can either download a pre-built image or building the container from source using one of the available `Dockerfile`s. 
+In either case, you will have to install Docker first. For that we refer you to the official `docker installation instructions <https://docs.docker.com/engine/install/>`_ .
 
-  * image based on Ubuntu 22.04
-  * all dependencies are installed
-  * petsc has all extra dependencies such as, e.g., HYPRE, PARMETIS etc.
-  * the core is built in debug and release target
-  * all examples are built in release target
-* ``maierbn/opendihu:2004``, ``maierbn/opendihu:1804``, ``maierbn/opendihu:1604``:
+* Using the pre-built docker image
+  * Pull the image from `DockerHub <https://hub.docker.com/r/carmehp/opendihu/tags>`_ 
+    .. code-block:: bash
 
-  * images based on Ubuntu 20.04, 18.04, and 16.04
-  * dependencies are installed (except preCICE), petsc only has standard functionality
-  * the core is built in release target
-  * examples are not yet built
+    docker image pull carmehp/opendihu
+  * Run the image
+    .. code-block:: bash
 
-First install `docker <https://docs.docker.com/engine/install/ubuntu/>`_ following the instructions on the website. Then, you can run the provided docker image with the following command:
+    docker run -i -t carmehp/opendihu
 
-.. code-block:: bash
+  By default, carmehp/opendihu is equivalent to ``carmehp/opendihu:latest``. If you want to use a different image, then you have to specify its tag: `carmehp/opendihu:<tag_name>`.
 
-  docker run -it maierbn/opendihu:latest bash
+* Building the docker image from source
+  * Select the image you want to build. All the available options are found in ``tools/docker/``. For example if you want to use the docker image based on Ubuntu 22.04, change to the corresponding directory where the Dockerfile is located.
+    .. code-block:: bash
 
-You can also build docker images yourself. We provide Dockerfiles to set up OpenDiHu containers that import Ubuntu 16.04, 18.04, 20.04 or 22.04. 
-To build one of the provided OpenDiHu container you have to
+    cd tools/docker/ubuntu22
+  * Build the image. The ``<image_name>`` can be choosen freely. This step will take some time, e.g., 30 minutes - 1 hour.
+    .. code-block:: bash
 
-  1. Change to the directory where `Dockerfile` is located, under ``tools/docker/ubuntu*``
-  2. Execute ``docker build -t workspace .``
+    docker build -t <image_name> .
+  * Run a container of the image. The ``<image_name>`` can be choosen freely.
+    .. code-block:: bash
 
-You can run the container you just built by executing ``docker run -it workspace``
+    docker run -i -t <image_name>  
+
 
 .. _Native installation:
 

--- a/doc/sphinx/user/installation.rst
+++ b/doc/sphinx/user/installation.rst
@@ -26,7 +26,7 @@ In either case, you will have to install Docker first. For that we refer you to 
   * Run the image
     .. code-block:: bash
 
-    docker run -i -t carmehp/opendihu
+    docker run -it carmehp/opendihu
 
   By default, carmehp/opendihu is equivalent to ``carmehp/opendihu:latest``. If you want to use a different image, then you have to specify its tag: `carmehp/opendihu:<tag_name>`.
 

--- a/doc/sphinx/user/installation.rst
+++ b/doc/sphinx/user/installation.rst
@@ -42,7 +42,7 @@ In either case, you will have to install Docker first. For that we refer you to 
   * Run a container of the image. The ``<image_name>`` can be choosen freely.
     .. code-block:: bash
 
-    docker run -i -t <image_name>  
+    docker run -it <image_name>  
 
 
 .. _Native installation:

--- a/doc/sphinx/user/installation.rst
+++ b/doc/sphinx/user/installation.rst
@@ -13,7 +13,7 @@ The docker image serves all the available functionality for executing simulation
 Using docker
 ----------------
 With the docker image, you can use the framework directly without having to build and install any dependencies. Parallel execution with MPI is possible.
-The disadvantage is that you only have a shell and can't plot anything. However, you may copy the files from the docker container to your machine and do the plotting there. 
+The disadvantage is that you only have a shell and can't plot anything. However, you may copy the files from the docker container to your machine (or directly mount the respective directory) and do the plotting there. 
 
 You can either download a pre-built image or building the container from source using one of the available `Dockerfile`s. 
 In either case, you will have to install Docker first. For that we refer you to the official `docker installation instructions <https://docs.docker.com/engine/install/>`_ .

--- a/tools/docker/docker_ci/.bash_aliases
+++ b/tools/docker/docker_ci/.bash_aliases
@@ -1,0 +1,40 @@
+# .bashrc 
+# The content of this file is to be added to the docker container dashfile
+export OPENDIHU_HOME=/workspace/opendihu
+
+export PATH=$PATH:$OPENDIHU_HOME/scripts
+export PATH=$PATH:$OPENDIHU_HOME/scripts/geometry_manipulation
+export PATH=$PATH:$OPENDIHU_HOME/scripts/file_manipulation
+
+# define convenience commands for compilation
+alias scons='$OPENDIHU_HOME/dependencies/scons/scons.py'
+alias s='scons'
+alias sd='$OPENDIHU_HOME/scripts/shortcuts/sd.sh'
+alias sdd='$OPENDIHU_HOME/scripts/shortcuts/sdd.sh'
+alias sddn='cd .. && scons BUILD_TYPE=d no_tests=yes no_examples=yes; cd -'
+alias sdn='scons BUILD_TYPE=d no_tests=yes no_examples=yes'
+alias srn='scons BUILD_TYPE=r no_tests=yes no_examples=yes'
+alias sr='$OPENDIHU_HOME/scripts/shortcuts/sr.sh'
+alias srd='$OPENDIHU_HOME/scripts/shortcuts/srd.sh'
+alias srr='$OPENDIHU_HOME/scripts/shortcuts/srr.sh'
+alias mkor='$OPENDIHU_HOME/scripts/shortcuts/mkor.sh'
+alias mkorn='$OPENDIHU_HOME/scripts/shortcuts/mkorn.sh'
+alias mkod='$OPENDIHU_HOME/scripts/shortcuts/mkod.sh'
+alias mkodn='$OPENDIHU_HOME/scripts/shortcuts/mkodn.sh'
+alias mkordn='$OPENDIHU_HOME/scripts/shortcuts/mkordn.sh'
+
+# optional convenience aliases
+alias ..="cd .."
+alias ...="cd ../.."
+alias ....="cd ../../.."
+alias l='ll -h'
+alias d='cd build_debug'
+alias r='cd build_release/'
+alias out='cd out'
+
+# command coloring
+parse_git_branch() {
+ git branch 2> /dev/null | sed -e '/^[^*]/d' -e 's/* \(.*\)/(\1)/'
+}
+PS1='\[\e[1;32m\]\u@\h\[\e[m\]\[\e[37m\] $(parse_git_branch)\[\e[m\] \[\e[1;30m\]\w\[\e[m\] \[\e[1;32m\]\n\$\[\e[m\]\[\e[1;37m\]'
+trap '[[ -t 1 ]] && tput sgr0' DEBUG

--- a/tools/docker/docker_ci/Dockerfile
+++ b/tools/docker/docker_ci/Dockerfile
@@ -1,0 +1,30 @@
+FROM ubuntu:22.04
+
+# Install prerequisites
+RUN apt-get update && \
+    apt-get install -y \
+    git \
+    wget unzip \
+    build-essential petsc-dev bison flex libeigen3-dev libxml2-dev libboost-all-dev \
+    cmake \
+    libffi-dev \
+    vim \
+    python-is-python3
+
+# git -> Dockerfile
+# wget unzip -> Download dependencies
+# build-essential petsc-dev bison flex libeigen3-dev libxml2-dev libboost-all-dev -> PETSc
+# cmake -> base64
+# libffi-dev -> Solves error at run time: ModuleNotFoundError: No module named '_ctypes’
+# vim -> optional
+# python-is-python3 -> make `python` point to python3 (needed for some scripts that call python instead of python3)
+
+WORKDIR /workspace
+
+# Clone opendihu
+RUN git clone --branch update-docker --depth=1 https://github.com/opendihu/opendihu.git  
+WORKDIR opendihu
+
+# Build opendihu, debug and release target for core, build release unit tests and run tests, build all examples
+RUN python3 dependencies/scons/scons.py BUILD_TYPE=RELEASE no_examples=TRUE; echo "Build core and run tests"; cat config.log
+

--- a/tools/docker/docker_ci/Dockerfile
+++ b/tools/docker/docker_ci/Dockerfile
@@ -22,7 +22,7 @@ RUN apt-get update && \
 WORKDIR /workspace
 
 # Clone opendihu
-RUN git clone --branch update-docker --depth=1 https://github.com/opendihu/opendihu.git  
+RUN git clone --branch develop --depth=1 https://github.com/opendihu/opendihu.git  
 WORKDIR opendihu
 
 # Build opendihu, debug and release target for core, build release unit tests and run tests, build all examples

--- a/tools/docker/docker_ci/Dockerfile
+++ b/tools/docker/docker_ci/Dockerfile
@@ -28,3 +28,12 @@ WORKDIR opendihu
 # Build opendihu, debug and release target for core, build release unit tests and run tests, build all examples
 RUN make release_without_tests; echo "Build and run tests";
 
+# Set environment variable such that OpenMPI works inside docker container (run as root)
+ENV OMPI_ALLOW_RUN_AS_ROOT=1
+ENV OMPI_ALLOW_RUN_AS_ROOT_CONFIRM=1
+ENV OMPI_MCA_btl_vader_single_copy_mechanism=none
+ENV OMPI_MCA_osc=ucx 
+
+# Add aliases
+ADD .bash_aliases /workspace
+RUN echo ". /workspace/.bash_aliases " >> ~/.bashrc 

--- a/tools/docker/docker_ci/Dockerfile
+++ b/tools/docker/docker_ci/Dockerfile
@@ -26,5 +26,5 @@ RUN git clone --branch update-docker --depth=1 https://github.com/opendihu/opend
 WORKDIR opendihu
 
 # Build opendihu, debug and release target for core, build release unit tests and run tests, build all examples
-RUN python3 dependencies/scons/scons.py BUILD_TYPE=RELEASE no_examples=TRUE; echo "Build core and run tests"; cat config.log
+RUN make release_without_tests; echo "Build and run tests";
 

--- a/tools/docker/docker_ci/Dockerfile
+++ b/tools/docker/docker_ci/Dockerfile
@@ -26,7 +26,7 @@ RUN git clone --branch update-docker --depth=1 https://github.com/opendihu/opend
 WORKDIR opendihu
 
 # Build opendihu, debug and release target for core, build release unit tests and run tests, build all examples
-RUN make release_without_tests; echo "Build and run tests";
+RUN make release; echo "Build and run tests";
 
 # Set environment variable such that OpenMPI works inside docker container (run as root)
 ENV OMPI_ALLOW_RUN_AS_ROOT=1

--- a/tools/docker/ubuntu22/Dockerfile
+++ b/tools/docker/ubuntu22/Dockerfile
@@ -22,7 +22,7 @@ RUN apt-get update && \
 WORKDIR /workspace
 
 # Clone opendihu
-RUN git clone --branch update-docker --depth=1 https://github.com/opendihu/opendihu.git  
+RUN git clone --branch develop --depth=1 https://github.com/opendihu/opendihu.git  
 WORKDIR opendihu
 
 # Build opendihu, debug and release target for core, build release unit tests and run tests, build all examples

--- a/tools/docker/ubuntu22/Dockerfile
+++ b/tools/docker/ubuntu22/Dockerfile
@@ -8,7 +8,8 @@ RUN apt-get update && \
     build-essential petsc-dev bison flex libeigen3-dev libxml2-dev libboost-all-dev \
     cmake \
     libffi-dev \
-    vim
+    vim \
+    python-is-python3
 
 # git -> Dockerfile
 # wget unzip -> Download dependencies
@@ -16,9 +17,7 @@ RUN apt-get update && \
 # cmake -> base64
 # libffi-dev -> Solves error at run time: ModuleNotFoundError: No module named '_ctypes’
 # vim -> optional
-
-# make `python` point to python3 (needed for some scripts that call python instead of python3)
-RUN update-alternatives --install /usr/bin/python python /usr/bin/python3 100
+# python-is-python3 -> make `python` point to python3 (needed for some scripts that call python instead of python3)
 
 WORKDIR /workspace
 

--- a/tools/docker/ubuntu22/Dockerfile
+++ b/tools/docker/ubuntu22/Dockerfile
@@ -23,13 +23,11 @@ RUN update-alternatives --install /usr/bin/python python /usr/bin/python3 100
 WORKDIR /workspace
 
 # Clone opendihu
-RUN git clone --branch develop --depth=1 https://github.com/maierbn/opendihu.git  
+RUN git clone --branch update-docker --depth=1 https://github.com/opendihu/opendihu.git  
 WORKDIR opendihu
 
 # Build opendihu, debug and release target for core, build release unit tests and run tests, build all examples
-RUN make debug_without_tests; echo "make debug_without_tests done"
 RUN make release_without_tests; echo "make release_without_tests done"; cat config.log
-RUN make travis_ci; echo "build examples done"
 
 # Set environment variable such that OpenMPI works inside docker container (run as root)
 ENV OMPI_ALLOW_RUN_AS_ROOT=1

--- a/user-variables.scons.py
+++ b/user-variables.scons.py
@@ -25,6 +25,10 @@ cmake="cmake"      # cmake command
 PETSC_DOWNLOAD = True
 #PETSC_DIR = "/usr/lib/petsc/"
 
+SCR_DOWNLOAD = True
+HDF5_DOWNLOAD = True
+NLOHMANNJSON_DOWNLOAD = True
+
 # Python 3.9, note that this also builds the C-API which is usually not included in the normal python3 installation of your system, therefore it is recommended that you leave it at 'True'
 PYTHON_DOWNLOAD = True
 


### PR DESCRIPTION
## Main changes of this PR

- This PR changes the image downloaded from DockerHub used during CI. That way we replace maierbn (still pointing to the old repository and not updated in the last year) with carmehp. Here is the new image that the CI pulls from https://hub.docker.com/r/carmehp/opendihu (for now, just only tag latest available)
- It also changes the workflow file to not do a new checkout of the repository (see #18 )
- The image used for the CI is opendihu-ci, which differs from opendihu because it doesn't include the input files. The corresponding dockerfile has been added. 
- It also updates expands the dependencies installed in the image which are needed for checkpointing  #63. 

Before merging:

- [x] Change branch in Dockerfile to develop

**Issues that are addressed by this PR:** <!--Add references-->

<!--
If there are changes not described by the linked issues, insert a brief description here. 
-->


## Additional information

<!--
List known related issues, upcomming work, etc. 
-->

## Author's checklist

* [ ] I updated the documentation.
* [x] I used clang-formating.


