### PR TITLE
Add error message and return nullptr to avoid compile-warnings

### DIFF
--- a/core/src/control/precice/nested_solver_fast_monodomain_solver.tpp
+++ b/core/src/control/precice/nested_solver_fast_monodomain_solver.tpp
@@ -581,7 +581,11 @@ void PreciceAdapterNestedSolver<FastMonodomainSolver<T1>>::getTractionValues(
 
 template <typename T1>
 Vec PreciceAdapterNestedSolver<FastMonodomainSolver<T1>>::currentState(
-    NestedSolverType &nestedSolver) {}
+    NestedSolverType &nestedSolver) {
+  LOG(ERROR) << "Implicit coupling not supported! curentState is not "
+                "implemented for this preCICE adapter nested solver";
+  return nullptr;
+};
 
 template <typename T1>
 std::shared_ptr<


### PR DESCRIPTION
## Main changes of this PR

**Issues that are addressed by this PR:** #76 

The merging of the adapters led to the appearance of some compile warnings that are now addressed. 
<!--
If there are changes not described by the linked issues, insert a brief description here. 
-->


## Additional information

<!--
List known related issues, upcomming work, etc. 
-->

## Author's checklist

* [ ] I updated the documentation.
* [x] I used clang-formating.


