### PR TITLE
Update conventions.rst: Fix typo

### DIFF
--- a/doc/sphinx/developer/conventions.rst
+++ b/doc/sphinx/developer/conventions.rst
@@ -77,7 +77,7 @@ There you can set the file names to be included in the executable and fully enab
 
 .. note::
   
-  **IMPORTANT:** The tests require configuring PETSc with ParMETIS, which is not necessary to run many of the examples. To check if your PETSc installation is configured with ParMETIS use
+  **IMPORTANT:** The tests require configuring PETSc with ParMETIS, which is not necessary to run many of the examples. To check if your PETSc installation is configured with ParMETIS,
   use `ldd libpetsc.so` in `opendihu/dependencies/petsc/install/lib`. If you use Ubuntu 22.04, you will need to install the app packages `bison flex`. 
 
 


### PR DESCRIPTION
## Main changes of this PR

Fixes a typo in the documentation, follow-up of https://github.com/opendihu/opendihu/pull/82.


## Author's checklist

* [x] I updated the documentation.
* I used clang-formating. -> N/A


