### PR TITLE
Remove parts of logging messages uncompatible with gcc 12

### DIFF
--- a/core/src/cellml/source_code_generator/00_source_code_generator_base.cpp
+++ b/core/src/cellml/source_code_generator/00_source_code_generator_base.cpp
@@ -82,8 +82,7 @@ void CellmlSourceCodeGeneratorBase::initializeSourceCode(
     LOG(WARNING) << "In CellML: There should be " << nParameters_ << " = "
                  << parametersUsedAsAlgebraic_.size() << "+"
                  << parametersUsedAsConstant_.size()
-                 << " parameters (algebraics: " << parametersUsedAsAlgebraic_
-                 << ", constants: " << parametersUsedAsConstant_ << ") or "
+                 << " parameters or "
                  << nParameters_ * nInstances_
                  << " parameters in array of struct format, but "
                  << parametersInitialValues.size()

--- a/core/src/cellml/source_code_generator/00_source_code_generator_base.cpp
+++ b/core/src/cellml/source_code_generator/00_source_code_generator_base.cpp
@@ -81,8 +81,7 @@ void CellmlSourceCodeGeneratorBase::initializeSourceCode(
     // values in the settings
     LOG(WARNING) << "In CellML: There should be " << nParameters_ << " = "
                  << parametersUsedAsAlgebraic_.size() << "+"
-                 << parametersUsedAsConstant_.size()
-                 << " parameters or "
+                 << parametersUsedAsConstant_.size() << " parameters or "
                  << nParameters_ * nInstances_
                  << " parameters in array of struct format, but "
                  << parametersInitialValues.size()

--- a/core/src/utility/python_utility.tpp
+++ b/core/src/utility/python_utility.tpp
@@ -275,7 +275,7 @@ void PythonUtility::getOptionVector(const PyObject *settings,
     } else {
       LOG(WARNING) << "" << pathString << "[\"" << keyString
                    << "\"] not set in \"" << Control::settingsFileName
-                   << "\". Assuming vector " << values;
+                   << "\".";
     }
     Py_CLEAR(key);
   }

--- a/core/src/utility/python_utility.tpp
+++ b/core/src/utility/python_utility.tpp
@@ -274,8 +274,7 @@ void PythonUtility::getOptionVector(const PyObject *settings,
       }
     } else {
       LOG(WARNING) << "" << pathString << "[\"" << keyString
-                   << "\"] not set in \"" << Control::settingsFileName
-                   << "\".";
+                   << "\"] not set in \"" << Control::settingsFileName << "\".";
     }
     Py_CLEAR(key);
   }


### PR DESCRIPTION
## Main changes of this PR

This is a quick fix for a potentially bigger problem. We have removed part of the logging errors in order to be able to compile opendihu with gcc 12.

**Issues that are addressed by this PR:** <!--Add references--> #1

<!--
If there are changes not described by the linked issues, insert a brief description here. 
-->


## Additional information

<!--
List known related issues, upcomming work, etc. 
-->

## Author's checklist

* [ ] I used clang-formating.
* [ ] I updated the documentation.
* [ ] I updated hard-coded version numbers. 

