### PR TITLE
Define easylogingcpp macros needed for gcc12 compatibility

### DIFF
--- a/SConstructGeneral
+++ b/SConstructGeneral
@@ -237,10 +237,10 @@ if env["BUILD_TYPE"] == "debug":
   if env['CC'] != "pgcc":  # not pgi compiler
     env.MergeFlags('-ftemplate-backtrace-limit=0')
     env.MergeFlags('-Wall -Wpedantic -Wno-sign-compare -Wno-error=sign-compare')
-    env.MergeFlags('-DDEBUG -ggdb3 -g3 -Og  -DELPP_FEATURE_CRASH_LOG')   # gcc flags, will be sorted automatically into linker and compiler flags
+    env.MergeFlags('-DDEBUG -ggdb3 -g3 -Og  -DELPP_FEATURE_CRASH_LOG -DELPP_STL_LOGGING -DELPP_LOG_STD_ARRAY')   # gcc flags, will be sorted automatically into linker and compiler flags
   else: # using pgi compiler here:
 #    env.MergeFlags('-O0 -g -ta=host,tesla:cc60,time -Minfo=accel -noswitcherror -std=c++14 -DELPP_FEATURE_CRASH_LOG -laccg -laccapi -laccn -laccg2 -lcudadevice')
-    env.MergeFlags('-O0 -g -std=c++14 -DELPP_FEATURE_CRASH_LOG')
+    env.MergeFlags('-O0 -g -std=c++14 -DELPP_FEATURE_CRASH_LOG -DELPP_STL_LOGGING -DELPP_LOG_STD_ARRAY')
     env.MergeFlags('-DDEBUG -D__SSE__')
   if not env["USE_MEGAMOL"]:
     #env.MergeFlags('-Werror')
@@ -258,19 +258,19 @@ elif env["BUILD_TYPE"] == "releasewithdebuginfo":
 elif env["BUILD_TYPE"] == "preprocess":
   # only the preprocessing step
   variant_dir = os.path.join(path_where_to_call_sconscript,'preprocess')         # output folder for build
-  env.MergeFlags('-DDEBUG -O2 -ggdb3 -g3 -DELPP_DISABLE_DEBUG_LOGS -DELPP_DISABLE_VERBOSE_LOGS -DELPP_DISABLE_TRACE_LOGS -E -C -P ')   # gcc flags, will be sorted automatically into linker and compiler flags
+  env.MergeFlags('-DDEBUG -O2 -ggdb3 -g3 -DELPP_DISABLE_DEBUG_LOGS -DELPP_DISABLE_VERBOSE_LOGS -DELPP_DISABLE_TRACE_LOGS DELPP_STL_LOGGING -DELPP_LOG_STD_ARRAY -E -C -P ')   # gcc flags, will be sorted automatically into linker and compiler flags
 
 elif env["BUILD_TYPE"] == "assembly":
   # do the assembly
   variant_dir = os.path.join(path_where_to_call_sconscript,'assembly')         # output folder for build
-  env.MergeFlags('-DDEBUG -S -fverbose-asm -g -O2 -DELPP_DISABLE_DEBUG_LOGS -DELPP_DISABLE_VERBOSE_LOGS -DELPP_DISABLE_TRACE_LOGS ')   # gcc flags, will be sorted automatically into linker and compiler flags
+  env.MergeFlags('-DDEBUG -S -fverbose-asm -g -O2 -DELPP_DISABLE_DEBUG_LOGS -DELPP_DISABLE_VERBOSE_LOGS -DELPP_DISABLE_TRACE_LOGS DELPP_STL_LOGGING -DELPP_LOG_STD_ARRAY')   # gcc flags, will be sorted automatically into linker and compiler flags
 
 else:
   # release build
   variant_dir = os.path.join(path_where_to_call_sconscript,'build_release')         # output folder for build
   env.Append(LIBPATH = [os.path.join(opendihu_home, 'core/build_release')])   # add release version of opendihu library
   env.Prepend(LIBS = ['opendihu'])
-  env.MergeFlags('-DELPP_DISABLE_DEBUG_LOGS -DELPP_DISABLE_VERBOSE_LOGS -DELPP_DISABLE_TRACE_LOGS -DELPP_DISABLE_LOGGING_FLAGS_FROM_ARG -DNDEBUG -DDISABLE_LOG_SCOPE')
+  env.MergeFlags('-DELPP_DISABLE_DEBUG_LOGS -DELPP_DISABLE_VERBOSE_LOGS -DELPP_DISABLE_TRACE_LOGS -DELPP_DISABLE_LOGGING_FLAGS_FROM_ARG -DNDEBUG -DDISABLE_LOG_SCOPE -DELPP_STL_LOGGING -DELPP_LOG_STD_ARRAY')
   if os.environ.get("PE_ENV") == "CRAY":
     env.MergeFlags('-O3')   # fastest with cray (same performance as -02)
   elif env["CC"] == "pgcc":

--- a/core/src/cellml/source_code_generator/00_source_code_generator_base.cpp
+++ b/core/src/cellml/source_code_generator/00_source_code_generator_base.cpp
@@ -81,7 +81,9 @@ void CellmlSourceCodeGeneratorBase::initializeSourceCode(
     // values in the settings
     LOG(WARNING) << "In CellML: There should be " << nParameters_ << " = "
                  << parametersUsedAsAlgebraic_.size() << "+"
-                 << parametersUsedAsConstant_.size() << " parameters or "
+                 << parametersUsedAsConstant_.size()
+                 << " parameters (algebraics: " << parametersUsedAsAlgebraic_
+                 << ", constants: " << parametersUsedAsConstant_ << ") or "
                  << nParameters_ * nInstances_
                  << " parameters in array of struct format, but "
                  << parametersInitialValues.size()

--- a/core/src/control/initialization/initialize_easyloggingpp.cpp
+++ b/core/src/control/initialization/initialize_easyloggingpp.cpp
@@ -1,5 +1,3 @@
 
 #include "easylogging++.h"
-
-#define ELPP_LOG_STD_ARRAY 1
 INITIALIZE_EASYLOGGINGPP

--- a/core/src/output_writer/paraview/loop_collect_mesh_properties.tpp
+++ b/core/src/output_writer/paraview/loop_collect_mesh_properties.tpp
@@ -59,7 +59,7 @@ collectMeshProperties(
                << ", fielVariableType: "
                << StringUtility::demangle(
                       typeid(CurrentFieldVariableType).name())
-               << " fieldVariables: " << fieldVariables << ", i: " << i;
+               << " fieldVariables: " << ", i: " << i;
   }
   assert(currentFieldVariable != nullptr);
   if (!currentFieldVariable->functionSpace()) {
@@ -69,7 +69,7 @@ collectMeshProperties(
                << ", fielVariableType: "
                << StringUtility::demangle(
                       typeid(CurrentFieldVariableType).name())
-               << " fieldVariables: " << fieldVariables << ", i: " << i;
+               << " fieldVariables: " << ", i: " << i;
     return false;
   }
   assert(currentFieldVariable->functionSpace());

--- a/core/src/utility/python_utility.tpp
+++ b/core/src/utility/python_utility.tpp
@@ -274,7 +274,8 @@ void PythonUtility::getOptionVector(const PyObject *settings,
       }
     } else {
       LOG(WARNING) << "" << pathString << "[\"" << keyString
-                   << "\"] not set in \"" << Control::settingsFileName << "\".";
+                   << "\"] not set in \"" << Control::settingsFileName
+                   << "\". Assuming vector " << values;
     }
     Py_CLEAR(key);
   }


### PR DESCRIPTION
## Main changes of this PR

We had the problem that vectors and arrays could not be logged if gcc 12 was used. Seems that it is needed to define the macros `ELPP_STL_LOGGING` and `ELPP_LOG_STD_ARRAY` ([see documentation](https://github.com/abumq/easyloggingpp#stl-logging)).
Actually the last was already there in initialize_easyloggingcpp.cpp but it seems like having it there does not work. 

- The macros don't work for std::tuple. That's why I had to modify https://github.com/opendihu/opendihu/pull/94/files#diff-8019d4f8bb5ef833533a63370dac45693ade3bf89f851f00993d3aa1c4e96e62

- With defining the macros, the PR #86 can be undone
- This change would mean that we finally have gcc12 support!

**Issues that are addressed by this PR:** <!--Add references--> #1

<!--
If there are changes not described by the linked issues, insert a brief description here. 
-->


## Additional information

<!--
List known related issues, upcomming work, etc. 
-->

## Author's checklist

* [ ] I used pre-commit.
* [ ] I updated the documentation.
* [ ] I updated hard-coded version numbers. 

