### PR TITLE
Make precice installation faster

### DIFF
--- a/dependencies/scons-config/sconsconfig/packages/precice.py
+++ b/dependencies/scons-config/sconsconfig/packages/precice.py
@@ -128,7 +128,7 @@ class precice(Package):
           -DPRECICE_FEATURE_PYTHON_ACTIONS=OFF \
           -DLIBXML2_INCLUDE_DIR=${PREFIX}/include/libxml2 -DLIBXML2_LIBRARY=${PREFIX}/lib/libxml2.so \
           ..',
-        'cd ${SOURCE_DIR}/build && make precice install'
+        'cd ${SOURCE_DIR}/build && make -j 8 precice install'
       ])
       
       self.check_options(env)

--- a/dependencies/scons-config/sconsconfig/packages/precice.py
+++ b/dependencies/scons-config/sconsconfig/packages/precice.py
@@ -91,9 +91,11 @@ class precice(Package):
         # precice
         'cd ${SOURCE_DIR} && mkdir -p build && cd build && '+ctx.env["cmake"]+' -DCMAKE_INSTALL_PREFIX=${PREFIX} \
           -DCMAKE_BUILD_TYPE=Release \
+          -DBUILD_TESTING=OFF \
           -DPRECICE_FEATURE_PYTHON_ACTIONS=OFF \
+          -DPRECICE_RELEASE_WITH_DEBUG_LOG=True \
           ..',
-        'cd ${SOURCE_DIR}/build && make precice install'
+        'cd ${SOURCE_DIR}/build && make -j 8 precice install'
       ])
       
       res = super(precice, self).check(ctx)

--- a/dependencies/scons-config/sconsconfig/packages/precice.py
+++ b/dependencies/scons-config/sconsconfig/packages/precice.py
@@ -6,7 +6,7 @@ class precice(Package):
 
   def __init__(self, **kwargs):
     defaults = {
-        'download_url': 'https://github.com/precice/precice/archive/refs/tags/v3.2.0.zip',
+        'download_url': 'https://github.com/precice/precice/archive/refs/tags/v3.3.0.zip',
     }
     defaults.update(kwargs)
     super(precice, self).__init__(**defaults)

--- a/dependencies/scons-config/sconsconfig/packages/precice.py
+++ b/dependencies/scons-config/sconsconfig/packages/precice.py
@@ -91,9 +91,9 @@ class precice(Package):
         # precice
         'cd ${SOURCE_DIR} && mkdir -p build && cd build && '+ctx.env["cmake"]+' -DCMAKE_INSTALL_PREFIX=${PREFIX} \
           -DCMAKE_BUILD_TYPE=Release \
+          -DPRECICE_RELEASE_WITH_DEBUG_LOG=True \
           -DBUILD_TESTING=OFF \
           -DPRECICE_FEATURE_PYTHON_ACTIONS=OFF \
-          -DPRECICE_RELEASE_WITH_DEBUG_LOG=True \
           ..',
         'cd ${SOURCE_DIR}/build && make -j 8 precice install'
       ])
@@ -123,6 +123,8 @@ class precice(Package):
         # precice
         'cd ${SOURCE_DIR} && mkdir -p build && cd build && '+ctx.env["cmake"]+' -DCMAKE_INSTALL_PREFIX=${PREFIX} \
           -DCMAKE_BUILD_TYPE=Release \
+          -DPRECICE_RELEASE_WITH_DEBUG_LOG=True \
+          -DBUILD_TESTING=OFF \
           -DPRECICE_FEATURE_PYTHON_ACTIONS=OFF \
           -DLIBXML2_INCLUDE_DIR=${PREFIX}/include/libxml2 -DLIBXML2_LIBRARY=${PREFIX}/lib/libxml2.so \
           ..',


### PR DESCRIPTION
## Main changes of this PR



<!--
If there are changes not described by the linked issues, insert a brief description here. 
-->
- Remove building preCICE test
- `make -j 8 precice install` instead `make precice install`


**Unrelated but useful**
- Add debug log : `-DPRECICE_RELEASE_WITH_DEBUG_LOG=True`

## Additional information

<!--
List known related issues, upcomming work, etc. 
-->

## Author's checklist

* [ ] I used pre-commit.
* [ ] I updated the documentation.
* [ ] I updated hard-coded version numbers. 

