### PR TITLE
Support fibers with different length

### DIFF
--- a/core/src/specialized_solver/fast_monodomain_solver/fast_monodomain_solver_compute.tpp
+++ b/core/src/specialized_solver/fast_monodomain_solver/fast_monodomain_solver_compute.tpp
@@ -187,7 +187,7 @@ void FastMonodomainSolverBase<
     LOG(DEBUG) << "inside loop over pointBuffers, iteration " << pointBuffersNo << "/"
                << nPointBuffers;
 
-    // determine if the point buffer belongs to a new fiberDataNo (0 means no, 1 means yes)
+    // determine if the point buffer belongs to a new fiberDataNo
     const bool newFiber = (pointBuffersNo-pointBuffersNoLastFiberDataNo) * Vc::double_v::size() / fiberData_[fiberDataNo].valuesLength;
 
     if (newFiber) {

--- a/core/src/specialized_solver/fast_monodomain_solver/fast_monodomain_solver_compute.tpp
+++ b/core/src/specialized_solver/fast_monodomain_solver/fast_monodomain_solver_compute.tpp
@@ -184,7 +184,7 @@ void FastMonodomainSolverBase<
 
   for (global_no_t pointBuffersNo = 0; pointBuffersNo < nPointBuffers;
        pointBuffersNo++) {
-    LOG(DEBUG) << "inside for, iteration " << pointBuffersNo << "/"
+    LOG(DEBUG) << "inside loop over pointBuffers, iteration " << pointBuffersNo << "/"
                << nPointBuffers;
 
     // determine if the point buffer belongs to a new fiberDataNo (0 means no, 1 means yes)

--- a/core/src/specialized_solver/fast_monodomain_solver/fast_monodomain_solver_compute.tpp
+++ b/core/src/specialized_solver/fast_monodomain_solver/fast_monodomain_solver_compute.tpp
@@ -188,7 +188,7 @@ void FastMonodomainSolverBase<
                << nPointBuffers;
 
     // determine if the point buffer belongs to a new fiberDataNo (0 means no, 1 means yes)
-    const bool newFiber = (pointBuffersNo-pointBuffersNoLastFiberDataNo) * (double)Vc::double_v::size() / fiberData_[fiberDataNo].valuesLength;
+    const bool newFiber = (pointBuffersNo-pointBuffersNoLastFiberDataNo) * Vc::double_v::size() / fiberData_[fiberDataNo].valuesLength;
 
     if (newFiber) {
       pointBuffersNoLastFiberDataNo = pointBuffersNo;

--- a/core/src/specialized_solver/fast_monodomain_solver/fast_monodomain_solver_compute.tpp
+++ b/core/src/specialized_solver/fast_monodomain_solver/fast_monodomain_solver_compute.tpp
@@ -180,7 +180,7 @@ void FastMonodomainSolverBase<
   fiberPointBuffersStatesAreCloseToEquilibrium_[nPointBuffers - 1] = active;
   
   int fiberDataNo = 0;
-  int pointBuffersNoLastFiberDataNo = 0;
+  int pointBuffersNoAtFiberStart = 0;
 
   for (global_no_t pointBuffersNo = 0; pointBuffersNo < nPointBuffers;
        pointBuffersNo++) {
@@ -188,10 +188,10 @@ void FastMonodomainSolverBase<
                << nPointBuffers;
 
     // determine if the point buffer belongs to a new fiberDataNo
-    const bool newFiber = (pointBuffersNo-pointBuffersNoLastFiberDataNo) * Vc::double_v::size() / fiberData_[fiberDataNo].valuesLength;
+    const bool newFiber = (pointBuffersNo-pointBuffersNoAtFiberStart) * Vc::double_v::size() / fiberData_[fiberDataNo].valuesLength;
 
     if (newFiber) {
-      pointBuffersNoLastFiberDataNo = pointBuffersNo;
+      pointBuffersNoAtFiberStart = pointBuffersNo;
       fiberDataNo++;
       LOG(DEBUG) << "at pointbuffersNo " << pointBuffersNo << " starts fiberDataNo: " << fiberDataNo << " with size: " << fiberData_[fiberDataNo].valuesLength;
     }

--- a/core/src/specialized_solver/fast_monodomain_solver/fast_monodomain_solver_compute.tpp
+++ b/core/src/specialized_solver/fast_monodomain_solver/fast_monodomain_solver_compute.tpp
@@ -178,9 +178,6 @@ void FastMonodomainSolverBase<
   // neighbors
   fiberPointBuffersStatesAreCloseToEquilibrium_[0] = active;
   fiberPointBuffersStatesAreCloseToEquilibrium_[nPointBuffers - 1] = active;
-
-
-  LOG(DEBUG) << "after setting point buffers active";
   
   int fiberDataNo = 0;
   int pointBuffersNoLastFiberDataNo = 0;

--- a/core/src/specialized_solver/fast_monodomain_solver/fast_monodomain_solver_compute.tpp
+++ b/core/src/specialized_solver/fast_monodomain_solver/fast_monodomain_solver_compute.tpp
@@ -191,9 +191,9 @@ void FastMonodomainSolverBase<
                << nPointBuffers;
 
     // determine if the point buffer belongs to a new fiberDataNo (0 means no, 1 means yes)
-    const int newFiber = (pointBuffersNo-pointBuffersNoLastFiberDataNo) * (double)Vc::double_v::size() / fiberData_[fiberDataNo].valuesLength;
+    const bool newFiber = (pointBuffersNo-pointBuffersNoLastFiberDataNo) * (double)Vc::double_v::size() / fiberData_[fiberDataNo].valuesLength;
 
-    if (newFiber > 0) {
+    if (newFiber) {
       pointBuffersNoLastFiberDataNo = pointBuffersNo;
       fiberDataNo++;
       LOG(DEBUG) << "at pointbuffersNo " << pointBuffersNo << " starts fiberDataNo: " << fiberDataNo << " with size: " << fiberData_[fiberDataNo].valuesLength;

--- a/core/src/specialized_solver/fast_monodomain_solver/fast_monodomain_solver_compute.tpp
+++ b/core/src/specialized_solver/fast_monodomain_solver/fast_monodomain_solver_compute.tpp
@@ -194,7 +194,6 @@ void FastMonodomainSolverBase<
       pointBuffersNoLastFiberDataNo = pointBuffersNo;
       fiberDataNo++;
       LOG(DEBUG) << "at pointbuffersNo " << pointBuffersNo << " starts fiberDataNo: " << fiberDataNo << " with size: " << fiberData_[fiberDataNo].valuesLength;
-
     }
 
     int indexInFiber = pointBuffersNo * Vc::double_v::size() -

--- a/core/src/specialized_solver/fast_monodomain_solver/fast_monodomain_solver_compute.tpp
+++ b/core/src/specialized_solver/fast_monodomain_solver/fast_monodomain_solver_compute.tpp
@@ -179,11 +179,27 @@ void FastMonodomainSolverBase<
   fiberPointBuffersStatesAreCloseToEquilibrium_[0] = active;
   fiberPointBuffersStatesAreCloseToEquilibrium_[nPointBuffers - 1] = active;
 
-  const double factorForForDataNo =
-      (double)Vc::double_v::size() / fiberData_[0].valuesLength;
+
+  LOG(DEBUG) << "after setting point buffers active";
+  
+  int fiberDataNo = 0;
+  int pointBuffersNoLastFiberDataNo = 0;
+
   for (global_no_t pointBuffersNo = 0; pointBuffersNo < nPointBuffers;
        pointBuffersNo++) {
-    int fiberDataNo = pointBuffersNo * factorForForDataNo;
+    LOG(DEBUG) << "inside for, iteration " << pointBuffersNo << "/"
+               << nPointBuffers;
+
+    // determine if the point buffer belongs to a new fiberDataNo (0 means no, 1 means yes)
+    const int newFiber = (pointBuffersNo-pointBuffersNoLastFiberDataNo) * (double)Vc::double_v::size() / fiberData_[fiberDataNo].valuesLength;
+
+    if (newFiber > 0) {
+      pointBuffersNoLastFiberDataNo = pointBuffersNo;
+      fiberDataNo++;
+      LOG(DEBUG) << "at pointbuffersNo " << pointBuffersNo << " starts fiberDataNo: " << fiberDataNo << " with size: " << fiberData_[fiberDataNo].valuesLength;
+
+    }
+
     int indexInFiber = pointBuffersNo * Vc::double_v::size() -
                        fiberData_[fiberDataNo].valuesOffset;
 
@@ -217,6 +233,8 @@ void FastMonodomainSolverBase<
 
     // loop over timesteps
     for (int timeStepNo = 0; timeStepNo < nTimeSteps; timeStepNo++) {
+      LOG(DEBUG) << "inside time step loop, iteration " << timeStepNo << "/"
+                 << nTimeSteps;
       // determine if fiber gets stimulated
       double currentTime = startTime + timeStepNo * timeStepWidth;
 
@@ -372,12 +390,14 @@ void FastMonodomainSolverBase<
     // x_i = d'_i - c'_i * x_{i+1}
 
     // helper buffers c', d'
-    static std::vector<double> cAlgebraic(nValues - 1);
-    static std::vector<double> dAlgebraic(nValues);
+    std::vector<double> cAlgebraic(nValues - 1);
+    std::vector<double> dAlgebraic(nValues);
 
     // perform forward substitution
     // loop over entries / rows of matrices
     for (int valueNo = 0; valueNo < nValues; valueNo++) {
+      LOG(DEBUG) << "for fiberDataNo "<< fiberDataNo <<" in config named " << fiberData_[fiberDataNo].fiberNoGlobal << ", forward substitution, valueNo: " << valueNo << "/"
+                 << nValues;
       // new with CN
       double a = 0;
       double b = 0;


### PR DESCRIPTION
## Main changes of this PR

- Change how we compute to which fiber a `pointBufferNo` belongs. Now we check how many buffers the current fiber should have, and if the current buffer is higher than the number of buffers that the fiber should have, we start a new fiber. 

- Remove keyword `static` so that the size of the vector is recomputed for each fiber in the for loop.
```
static std::vector<double> cAlgebraic(nValues - 1);
static std::vector<double> dAlgebraic(nValues);
```

**Issues that are addressed by this PR:** #109 



## Additional information



<!--
List known related issues, upcomming work, etc. 
-->

## Author's checklist

* [ ] I used pre-commit.
* [ ] I updated the documentation.
* [ ] I updated hard-coded version numbers. 

