### PR TITLE
Support fibers of different length in the adapter

### DIFF
--- a/core/src/control/precice/nested_solver_fast_monodomain_solver.tpp
+++ b/core/src/control/precice/nested_solver_fast_monodomain_solver.tpp
@@ -528,7 +528,7 @@ void PreciceAdapterNestedSolver<FastMonodomainSolver<T1>>::preciceWriteData(
           //   int slotNo, int arrayIndex, const std::vector<dof_no_t>
           //   &dofNosLocal, std::vector<double> &values);
             dofNosLocalWithoutGhosts.resize(nDofsLocalWithoutGhosts);
-            LOG(INFO) << "Getting values for slot No " << preciceData.slotNo
+            LOG(DEBUG) << "Getting values for slot No " << preciceData.slotNo
                     << ", arrayIndex " << arrayIndex
                     << ", nDofsLocalWithoutGhosts: " << nDofsLocalWithoutGhosts << ", dofNosLocalWithoutGhosts.size(): " << dofNosLocalWithoutGhosts.size();
             SlotConnectorDataHelper<SlotConnectorDataType>::slotGetValues(

--- a/core/src/control/precice/nested_solver_fast_monodomain_solver.tpp
+++ b/core/src/control/precice/nested_solver_fast_monodomain_solver.tpp
@@ -101,7 +101,6 @@ void PreciceAdapterNestedSolver<FastMonodomainSolver<T1>>::
             [&currentMeshName](std::shared_ptr<PreciceVolumeMesh> preciceMesh) {
               return preciceMesh->preciceMeshName == currentMeshName;
             });
-    int nPreciceNodesFromFibers = 0;
     // if the mesh is not in preciceVolumeMeshes, create it and add it to
     // preciceVolumeMeshes
     if (iter == preciceVolumeMeshes.end()) {
@@ -164,6 +163,7 @@ void PreciceAdapterNestedSolver<FastMonodomainSolver<T1>>::
 
         
         std::shared_ptr<Partition::MeshPartitionBase> meshPartitionBase;
+        int nPreciceNodesFromFibers = 0;
 
         for (int arrayIndex = 0; arrayIndex < nArrayItems; arrayIndex++) {
            // get the mesh partition

--- a/core/src/control/precice/nested_solver_fast_monodomain_solver.tpp
+++ b/core/src/control/precice/nested_solver_fast_monodomain_solver.tpp
@@ -286,23 +286,8 @@ void PreciceAdapterNestedSolver<FastMonodomainSolver<T1>>::
         SlotConnectorDataHelper<SlotConnectorDataType>::nArrayItems(
             slotConnectorData,
             preciceData.slotNo); // number of fibers if there are fibers
-    LOG(INFO) << "after nArrayItems, nDofsLocalWithoutGhosts: " << nDofsLocalWithoutGhosts
+    LOG(INFO) << "after nArrayItems,  nPreciceNodesFromFibers: " << nPreciceNodesFromFibers
               << ", nArrayItems: " << nArrayItems;
-    LOG(INFO) << "before loop over fibers, nPreciceNodesFromFibers: " << nPreciceNodesFromFibers;
-    nPreciceNodesFromFibers = 0;
-    for (int arrayIndex = 0; arrayIndex < nArrayItems; arrayIndex++) {
-    // get the mesh partition
-    meshPartitionBase =
-        SlotConnectorDataHelper<
-            SlotConnectorDataType>::getMeshPartitionBase(slotConnectorData,
-                                                        preciceData.slotNo,
-                                                        arrayIndex);
-    
-
-    int nDofsLocalWithoutGhosts = meshPartitionBase->nDofsLocalWithoutGhosts();
-    nPreciceNodesFromFibers += nDofsLocalWithoutGhosts;
-    
-    }
     
     if (nPreciceNodesFromFibers !=
         preciceData.preciceMesh->nNodesLocal) {

--- a/core/src/control/precice/nested_solver_fast_monodomain_solver.tpp
+++ b/core/src/control/precice/nested_solver_fast_monodomain_solver.tpp
@@ -380,11 +380,10 @@ void PreciceAdapterNestedSolver<FastMonodomainSolver<T1>>::preciceReadData(
       std::shared_ptr<Partition::MeshPartitionBase> meshPartitionBase =
           SlotConnectorDataHelper<SlotConnectorDataType>::getMeshPartitionBase(
               slotConnectorData, preciceData.slotNo, 0);
-      LOG(INFO)<<"right after getMeshPartitionBase";
 
       int nDofsLocalWithoutGhosts =
           meshPartitionBase->nDofsLocalWithoutGhosts();
-      LOG(INFO)<<"nDofsLocalWithoutGhosts: " << nDofsLocalWithoutGhosts;
+      LOG(DEBUG)<<"nDofsLocalWithoutGhosts: " << nDofsLocalWithoutGhosts;
 
       // get the vector of values [0,1,...,nDofsLocalWithGhosts]
       const std::vector<PetscInt> &dofNosLocalWithGhosts =
@@ -433,7 +432,6 @@ void PreciceAdapterNestedSolver<FastMonodomainSolver<T1>>::preciceReadData(
           SlotConnectorDataHelper<SlotConnectorDataType>::slotSetGeometryValues(
               slotConnectorData, preciceData.slotNo, arrayIndex,
               dofNosLocalWithoutGhosts, geometryValues_);
-        LOG(INFO) << "after looping over fibers";
         }
       } else {
         LOG(INFO) << "Setting values for slot No " << preciceData.slotNo
@@ -452,7 +450,6 @@ void PreciceAdapterNestedSolver<FastMonodomainSolver<T1>>::preciceReadData(
               slotConnectorData, preciceData.slotNo, arrayIndex,
               dofNosLocalWithoutGhosts, scalarValuesOfMesh_);
         }
-        LOG(INFO) << "after looping over fibers";
       }
     }
   }
@@ -588,10 +585,7 @@ void PreciceAdapterNestedSolver<FastMonodomainSolver<T1>>::preciceWriteData(
 
           LOG(INFO) << "Wrote " << scalarValues_.size() << " values to precice for data \""
                      << preciceData.preciceDataName << "\" on mesh \""
-                     << preciceData.preciceMesh->preciceMeshName
-                     << "\" the first three values are: " << 
-                     scalarValues_[0] << ", " << scalarValues_[1] << ", " << scalarValues_[2];
-
+                     << preciceData.preciceMesh->preciceMeshName;
     }
   }
   LOG(DEBUG) << "write volume data to precice complete";

--- a/core/src/control/precice/nested_solver_fast_monodomain_solver.tpp
+++ b/core/src/control/precice/nested_solver_fast_monodomain_solver.tpp
@@ -31,6 +31,8 @@ void PreciceAdapterNestedSolver<FastMonodomainSolver<T1>>::
       typename NestedSolverType::SlotConnectorDataType;
   std::shared_ptr<SlotConnectorDataType> slotConnectorData =
       nestedSolver.getSlotConnectorData();
+  int nPreciceNodesFromFibers = 0;
+
 
   // get all present slot names
   std::vector<std::string> slotNames;
@@ -164,7 +166,6 @@ void PreciceAdapterNestedSolver<FastMonodomainSolver<T1>>::
 
         
         std::shared_ptr<Partition::MeshPartitionBase> meshPartitionBase;
-        int nPreciceNodesFromFibers = 0;
 
         for (int arrayIndex = 0; arrayIndex < nArrayItems; arrayIndex++) {
            // get the mesh partition

--- a/core/src/control/precice/nested_solver_fast_monodomain_solver.tpp
+++ b/core/src/control/precice/nested_solver_fast_monodomain_solver.tpp
@@ -101,7 +101,7 @@ void PreciceAdapterNestedSolver<FastMonodomainSolver<T1>>::
             [&currentMeshName](std::shared_ptr<PreciceVolumeMesh> preciceMesh) {
               return preciceMesh->preciceMeshName == currentMeshName;
             });  
-                  
+
     // if the mesh is not in preciceVolumeMeshes, create it and add it to
     // preciceVolumeMeshes
     if (iter == preciceVolumeMeshes.end()) {
@@ -287,6 +287,7 @@ void PreciceAdapterNestedSolver<FastMonodomainSolver<T1>>::
             preciceData.slotNo); // number of fibers if there are fibers
     LOG(INFO) << "after nArrayItems, nDofsLocalWithoutGhosts: " << nDofsLocalWithoutGhosts
               << ", nArrayItems: " << nArrayItems;
+    LOG(INFO) << "before loop over fibers, nPreciceNodesFromFibers: " << nPreciceNodesFromFibers;
     nPreciceNodesFromFibers = 0;
     for (int arrayIndex = 0; arrayIndex < nArrayItems; arrayIndex++) {
     // get the mesh partition
@@ -307,9 +308,6 @@ void PreciceAdapterNestedSolver<FastMonodomainSolver<T1>>::
       LOG(DEBUG) << ", all available slots: "
                  << SlotConnectorDataHelper<SlotConnectorDataType>::getString(
                         slotConnectorData);
-      LOG(INFO) << "After logging all available slots";
-      LOG(INFO)<< "nPreciceNodesFromFibers: " << nPreciceNodesFromFibers
-                << ", preciceMesh->nNodesLocal: " << preciceData.preciceMesh->nNodesLocal;
       LOG(FATAL)
           << currentPreciceData
           << ": Mesh does not match slot in "

--- a/core/src/control/precice/nested_solver_fast_monodomain_solver.tpp
+++ b/core/src/control/precice/nested_solver_fast_monodomain_solver.tpp
@@ -211,7 +211,7 @@ void PreciceAdapterNestedSolver<FastMonodomainSolver<T1>>::
 
         preciceMesh->nNodesLocal = nPreciceNodesFromFibers;
 
-        LOG(INFO) << "Collected " << geometryValues.size()
+        LOG(DEBUG) << "collected " << geometryValues.size()
                    << " node positions from the " << nArrayItems << " fibers";
 
       }

--- a/core/src/control/precice/nested_solver_fast_monodomain_solver.tpp
+++ b/core/src/control/precice/nested_solver_fast_monodomain_solver.tpp
@@ -185,7 +185,7 @@ void PreciceAdapterNestedSolver<FastMonodomainSolver<T1>>::
 
             int nDofsLocalWithoutGhosts = meshPartitionBase->nDofsLocalWithoutGhosts();
             nPreciceNodesFromFibers += nDofsLocalWithoutGhosts;
-            LOG(INFO) << "nPreciceNodesFromFibers (after adding fiber " << arrayIndex << "): " << nPreciceNodesFromFibers
+            LOG(DEBUG) << "nPreciceNodesFromFibers (after adding fiber " << arrayIndex << "): " << nPreciceNodesFromFibers
                       << ", nDofsLocalWithoutGhosts: " << nDofsLocalWithoutGhosts
                       << ", nArrayItems: " << nArrayItems;
 
@@ -215,8 +215,6 @@ void PreciceAdapterNestedSolver<FastMonodomainSolver<T1>>::
                    << " node positions from the " << nArrayItems << " fibers";
 
       }
-      LOG(INFO) << "after finished collecting geometry values, nPreciceNodesFromFibers: " << nPreciceNodesFromFibers
-                << ", nArrayItems: " << nArrayItems;
 
       // transform to contiguous memory layout for precice
       std::vector<double> geometryValuesContiguous(3 * geometryValues.size());

--- a/core/src/control/precice/nested_solver_fast_monodomain_solver.tpp
+++ b/core/src/control/precice/nested_solver_fast_monodomain_solver.tpp
@@ -410,7 +410,7 @@ void PreciceAdapterNestedSolver<FastMonodomainSolver<T1>>::preciceReadData(
               slotConnectorData, preciceData.slotNo, arrayIndex);
          nDofsLocalWithoutGhosts =
           meshPartitionBase->nDofsLocalWithoutGhosts();
-        LOG(INFO) << "inside fiber loop,  for arrayIndex " << arrayIndex << "/" << nArrayItems << ", nDofsLocalWithoutGhosts: " << nDofsLocalWithoutGhosts;
+        LOG(DEBUG) << "inside fiber loop,  for arrayIndex " << arrayIndex << "/" << nArrayItems << ", nDofsLocalWithoutGhosts: " << nDofsLocalWithoutGhosts;
           geometryValues_.resize(nDofsLocalWithoutGhosts);
           for (int dofNoLocal = 0; dofNoLocal < nDofsLocalWithoutGhosts;
                dofNoLocal++) {
@@ -424,15 +424,12 @@ void PreciceAdapterNestedSolver<FastMonodomainSolver<T1>>::preciceReadData(
             }
           }
           scalarValueIndex += nDofsLocalWithoutGhosts;
-        LOG(INFO) << "before slotsetgeometryvalues";
       // get the vector of values [0,1,...,nDofsLocalWithGhosts]
       const std::vector<PetscInt> &dofNosLocalWithGhosts =
           meshPartitionBase->dofNosLocal();
       std::vector<PetscInt> dofNosLocalWithoutGhosts(
           dofNosLocalWithGhosts.begin(),
           dofNosLocalWithGhosts.begin() + nDofsLocalWithoutGhosts);
-        LOG(INFO) << "After getting dofNosLocalWithoutGhosts, with size " << dofNosLocalWithoutGhosts.size() << ", before slotSetGeometryValues";
-
           SlotConnectorDataHelper<SlotConnectorDataType>::slotSetGeometryValues(
               slotConnectorData, preciceData.slotNo, arrayIndex,
               dofNosLocalWithoutGhosts, geometryValues_);

--- a/core/src/control/precice/nested_solver_fast_monodomain_solver.tpp
+++ b/core/src/control/precice/nested_solver_fast_monodomain_solver.tpp
@@ -31,6 +31,8 @@ void PreciceAdapterNestedSolver<FastMonodomainSolver<T1>>::
       typename NestedSolverType::SlotConnectorDataType;
   std::shared_ptr<SlotConnectorDataType> slotConnectorData =
       nestedSolver.getSlotConnectorData();
+
+  // intialize the number of precice nodes from fibers to 0    
   int nPreciceNodesFromFibers = 0;
 
 
@@ -213,7 +215,7 @@ void PreciceAdapterNestedSolver<FastMonodomainSolver<T1>>::
                    << " node positions from the " << nArrayItems << " fibers";
 
       }
-      LOG(INFO) << "after Finished collecting geometry values, nPreciceNodesFromFibers: " << nPreciceNodesFromFibers
+      LOG(INFO) << "after finished collecting geometry values, nPreciceNodesFromFibers: " << nPreciceNodesFromFibers
                 << ", nArrayItems: " << nArrayItems;
 
       // transform to contiguous memory layout for precice

--- a/core/src/control/precice/nested_solver_fast_monodomain_solver.tpp
+++ b/core/src/control/precice/nested_solver_fast_monodomain_solver.tpp
@@ -100,7 +100,8 @@ void PreciceAdapterNestedSolver<FastMonodomainSolver<T1>>::
             preciceVolumeMeshes.begin(), preciceVolumeMeshes.end(),
             [&currentMeshName](std::shared_ptr<PreciceVolumeMesh> preciceMesh) {
               return preciceMesh->preciceMeshName == currentMeshName;
-            });
+            });  
+                  
     // if the mesh is not in preciceVolumeMeshes, create it and add it to
     // preciceVolumeMeshes
     if (iter == preciceVolumeMeshes.end()) {
@@ -191,8 +192,6 @@ void PreciceAdapterNestedSolver<FastMonodomainSolver<T1>>::
             std::vector<PetscInt> dofNosLocalWithoutGhosts(
                 dofNosLocalWithGhosts.begin(),
                 dofNosLocalWithGhosts.begin() + nDofsLocalWithoutGhosts);
-            LOG(INFO) << "nDofsLocalWithoutGhosts: " << nDofsLocalWithoutGhosts
-                    << ", nArrayItems: " << nArrayItems;
 
             static std::vector<Vec3> nodePositionsFiber;
             nodePositionsFiber.clear();
@@ -208,14 +207,8 @@ void PreciceAdapterNestedSolver<FastMonodomainSolver<T1>>::
         }
 
         preciceMesh->nNodesLocal = nPreciceNodesFromFibers;
-        LOG(INFO) << "After looping over fibers, nPreciceNodesFromFibers: " << nPreciceNodesFromFibers
-                  << ", nArrayItems: " << nArrayItems;
 
-
-
-
-
-        LOG(INFO) << "collected " << geometryValues.size()
+        LOG(INFO) << "Collected " << geometryValues.size()
                    << " node positions from the " << nArrayItems << " fibers";
 
       }
@@ -235,12 +228,6 @@ void PreciceAdapterNestedSolver<FastMonodomainSolver<T1>>::
 
       // resize buffer for vertex ids
       preciceMesh->preciceVertexIds.resize(preciceMesh->nNodesLocal);
-      LOG(INFO) << "Initialized precice mesh \"" << preciceMesh->preciceMeshName
-                << "\" from opendihu mesh \"" << preciceMesh->opendihuMeshName
-                << "\" with " << geometryValues.size() << " geometry values. ";
-
-      for (auto &value : geometryValuesContiguous)
-        LOG(INFO) << "contiguous geometry value: " << value;
 
       // give the node positions to precice and get the vertex ids
       preciceParticipant->setMeshVertices(preciceMesh->preciceMeshName,

--- a/core/src/control/precice/nested_solver_fast_monodomain_solver.tpp
+++ b/core/src/control/precice/nested_solver_fast_monodomain_solver.tpp
@@ -371,7 +371,6 @@ void PreciceAdapterNestedSolver<FastMonodomainSolver<T1>>::preciceReadData(
 
       // allocate temporary memory
       scalarValues_.resize(nEntries);
-
       // get all data at once
       preciceParticipant->readData(
           preciceData.preciceMesh->preciceMeshName, preciceData.preciceDataName,
@@ -381,9 +380,11 @@ void PreciceAdapterNestedSolver<FastMonodomainSolver<T1>>::preciceReadData(
       std::shared_ptr<Partition::MeshPartitionBase> meshPartitionBase =
           SlotConnectorDataHelper<SlotConnectorDataType>::getMeshPartitionBase(
               slotConnectorData, preciceData.slotNo, 0);
+      LOG(INFO)<<"right after getMeshPartitionBase";
 
       int nDofsLocalWithoutGhosts =
           meshPartitionBase->nDofsLocalWithoutGhosts();
+      LOG(INFO)<<"nDofsLocalWithoutGhosts: " << nDofsLocalWithoutGhosts;
 
       // get the vector of values [0,1,...,nDofsLocalWithGhosts]
       const std::vector<PetscInt> &dofNosLocalWithGhosts =
@@ -400,26 +401,47 @@ void PreciceAdapterNestedSolver<FastMonodomainSolver<T1>>::preciceReadData(
       // store received data in field variable
       if (preciceData.isGeometryField) {
         // loop over fibers if there are any
+        int scalarValueIndex = 0;
         for (int arrayIndex = 0; arrayIndex < nArrayItems; arrayIndex++) {
           // fill the vector geometryValues_ with the geometry values of the
           // current fiber or mesh
+          std::shared_ptr<Partition::MeshPartitionBase> meshPartitionBase =
+            SlotConnectorDataHelper<SlotConnectorDataType>::getMeshPartitionBase(
+              slotConnectorData, preciceData.slotNo, arrayIndex);
+         nDofsLocalWithoutGhosts =
+          meshPartitionBase->nDofsLocalWithoutGhosts();
+        LOG(INFO) << "inside fiber loop,  for arrayIndex " << arrayIndex << "/" << nArrayItems << ", nDofsLocalWithoutGhosts: " << nDofsLocalWithoutGhosts;
           geometryValues_.resize(nDofsLocalWithoutGhosts);
           for (int dofNoLocal = 0; dofNoLocal < nDofsLocalWithoutGhosts;
                dofNoLocal++) {
+            
             for (int componentNo = 0; componentNo < 3; componentNo++) {
               geometryValues_[dofNoLocal][componentNo] =
-                  scalarValues_[3 * (arrayIndex * nDofsLocalWithoutGhosts +
+                  scalarValues_[3 * (scalarValueIndex +
                                      dofNoLocal) +
                                 componentNo];
               //
             }
           }
+          scalarValueIndex += nDofsLocalWithoutGhosts;
+        LOG(INFO) << "before slotsetgeometryvalues";
+      // get the vector of values [0,1,...,nDofsLocalWithGhosts]
+      const std::vector<PetscInt> &dofNosLocalWithGhosts =
+          meshPartitionBase->dofNosLocal();
+      std::vector<PetscInt> dofNosLocalWithoutGhosts(
+          dofNosLocalWithGhosts.begin(),
+          dofNosLocalWithGhosts.begin() + nDofsLocalWithoutGhosts);
+        LOG(INFO) << "After getting dofNosLocalWithoutGhosts, with size " << dofNosLocalWithoutGhosts.size() << ", before slotSetGeometryValues";
 
           SlotConnectorDataHelper<SlotConnectorDataType>::slotSetGeometryValues(
               slotConnectorData, preciceData.slotNo, arrayIndex,
               dofNosLocalWithoutGhosts, geometryValues_);
+        LOG(INFO) << "after looping over fibers";
         }
       } else {
+        LOG(INFO) << "Setting values for slot No " << preciceData.slotNo
+                  << ", nDofsLocalWithoutGhosts: " << nDofsLocalWithoutGhosts
+                  << ", nArrayItems: " << nArrayItems;
         // loop over fibers if there are any
         for (int arrayIndex = 0; arrayIndex < nArrayItems; arrayIndex++) {
           // fill the vector geometryValues_ with the geometry values of the
@@ -433,6 +455,7 @@ void PreciceAdapterNestedSolver<FastMonodomainSolver<T1>>::preciceReadData(
               slotConnectorData, preciceData.slotNo, arrayIndex,
               dofNosLocalWithoutGhosts, scalarValuesOfMesh_);
         }
+        LOG(INFO) << "after looping over fibers";
       }
     }
   }

--- a/core/src/control/precice/nested_solver_fast_monodomain_solver.tpp
+++ b/core/src/control/precice/nested_solver_fast_monodomain_solver.tpp
@@ -101,7 +101,7 @@ void PreciceAdapterNestedSolver<FastMonodomainSolver<T1>>::
             [&currentMeshName](std::shared_ptr<PreciceVolumeMesh> preciceMesh) {
               return preciceMesh->preciceMeshName == currentMeshName;
             });
-
+    int nPreciceNodesFromFibers = 0;
     // if the mesh is not in preciceVolumeMeshes, create it and add it to
     // preciceVolumeMeshes
     if (iter == preciceVolumeMeshes.end()) {
@@ -149,54 +149,78 @@ void PreciceAdapterNestedSolver<FastMonodomainSolver<T1>>::
                    << StringUtility::demangle(
                           typeid(SlotConnectorDataType).name());
 
-        // get the mesh partition
-        std::shared_ptr<Partition::MeshPartitionBase> meshPartitionBase =
-            SlotConnectorDataHelper<
-                SlotConnectorDataType>::getMeshPartitionBase(slotConnectorData,
-                                                             preciceData.slotNo,
-                                                             0);
 
-        if (!meshPartitionBase) {
-          LOG(FATAL) << "Could not get mesh for slot No " << preciceData.slotNo;
-        } else
-          LOG(DEBUG) << "got mesh partition for slot No " << preciceData.slotNo;
 
         // get opendihu mesh name
         preciceMesh->opendihuMeshName =
             SlotConnectorDataHelper<SlotConnectorDataType>::getMeshName(
                 slotConnectorData, preciceData.slotNo);
 
-        int nDofsLocalWithoutGhosts =
-            meshPartitionBase->nDofsLocalWithoutGhosts();
         nArrayItems =
             SlotConnectorDataHelper<SlotConnectorDataType>::nArrayItems(
                 slotConnectorData,
                 preciceData.slotNo); // number of fibers if there are fibers
 
-        preciceMesh->nNodesLocal = nDofsLocalWithoutGhosts * nArrayItems;
 
-        // get the vector of values [0,1,...,nDofsLocalWithGhosts]
-        const std::vector<PetscInt> &dofNosLocalWithGhosts =
-            meshPartitionBase->dofNosLocal();
-        std::vector<PetscInt> dofNosLocalWithoutGhosts(
-            dofNosLocalWithGhosts.begin(),
-            dofNosLocalWithGhosts.begin() + nDofsLocalWithoutGhosts);
+        
+        std::shared_ptr<Partition::MeshPartitionBase> meshPartitionBase;
 
-        // loop over fibers if there are any
         for (int arrayIndex = 0; arrayIndex < nArrayItems; arrayIndex++) {
-          static std::vector<Vec3> nodePositionsFiber;
-          nodePositionsFiber.clear();
-          SlotConnectorDataHelper<SlotConnectorDataType>::slotGetGeometryValues(
-              slotConnectorData, preciceData.slotNo, arrayIndex,
-              dofNosLocalWithoutGhosts, nodePositionsFiber);
-          geometryValues.insert(geometryValues.end(),
-                                nodePositionsFiber.begin(),
-                                nodePositionsFiber.end());
+           // get the mesh partition
+            meshPartitionBase =
+                SlotConnectorDataHelper<
+                    SlotConnectorDataType>::getMeshPartitionBase(slotConnectorData,
+                                                                preciceData.slotNo,
+                                                                arrayIndex);
+
+            if (!meshPartitionBase) {
+            LOG(FATAL) << "Could not get mesh for slot No " << preciceData.slotNo;
+            } else
+            LOG(DEBUG) << "got mesh partition for slot No " << preciceData.slotNo;
+            
+
+            int nDofsLocalWithoutGhosts = meshPartitionBase->nDofsLocalWithoutGhosts();
+            nPreciceNodesFromFibers += nDofsLocalWithoutGhosts;
+            LOG(INFO) << "nPreciceNodesFromFibers (after adding fiber " << arrayIndex << "): " << nPreciceNodesFromFibers
+                      << ", nDofsLocalWithoutGhosts: " << nDofsLocalWithoutGhosts
+                      << ", nArrayItems: " << nArrayItems;
+
+                    // get the vector of values [0,1,...,nDofsLocalWithGhosts]
+            const std::vector<PetscInt> &dofNosLocalWithGhosts =
+                meshPartitionBase->dofNosLocal();
+            std::vector<PetscInt> dofNosLocalWithoutGhosts(
+                dofNosLocalWithGhosts.begin(),
+                dofNosLocalWithGhosts.begin() + nDofsLocalWithoutGhosts);
+            LOG(INFO) << "nDofsLocalWithoutGhosts: " << nDofsLocalWithoutGhosts
+                    << ", nArrayItems: " << nArrayItems;
+
+            static std::vector<Vec3> nodePositionsFiber;
+            nodePositionsFiber.clear();
+            SlotConnectorDataHelper<SlotConnectorDataType>::slotGetGeometryValues(
+                slotConnectorData, preciceData.slotNo, arrayIndex,
+                dofNosLocalWithoutGhosts, nodePositionsFiber);
+            LOG(INFO) << "For fiber " << arrayIndex << ", got geometry values for "
+                        << nodePositionsFiber.size() << " nodes.";
+            geometryValues.insert(geometryValues.end(),
+                                    nodePositionsFiber.begin(),
+                                    nodePositionsFiber.end());
+            
         }
 
-        LOG(DEBUG) << "collected " << geometryValues.size()
+        preciceMesh->nNodesLocal = nPreciceNodesFromFibers;
+        LOG(INFO) << "After looping over fibers, nPreciceNodesFromFibers: " << nPreciceNodesFromFibers
+                  << ", nArrayItems: " << nArrayItems;
+
+
+
+
+
+        LOG(INFO) << "collected " << geometryValues.size()
                    << " node positions from the " << nArrayItems << " fibers";
+
       }
+      LOG(INFO) << "after Finished collecting geometry values, nPreciceNodesFromFibers: " << nPreciceNodesFromFibers
+                << ", nArrayItems: " << nArrayItems;
 
       // transform to contiguous memory layout for precice
       std::vector<double> geometryValuesContiguous(3 * geometryValues.size());
@@ -211,6 +235,12 @@ void PreciceAdapterNestedSolver<FastMonodomainSolver<T1>>::
 
       // resize buffer for vertex ids
       preciceMesh->preciceVertexIds.resize(preciceMesh->nNodesLocal);
+      LOG(INFO) << "Initialized precice mesh \"" << preciceMesh->preciceMeshName
+                << "\" from opendihu mesh \"" << preciceMesh->opendihuMeshName
+                << "\" with " << geometryValues.size() << " geometry values. ";
+
+      for (auto &value : geometryValuesContiguous)
+        LOG(INFO) << "contiguous geometry value: " << value;
 
       // give the node positions to precice and get the vertex ids
       preciceParticipant->setMeshVertices(preciceMesh->preciceMeshName,
@@ -236,7 +266,6 @@ void PreciceAdapterNestedSolver<FastMonodomainSolver<T1>>::
       LOG(DEBUG) << "Use existing precice mesh " << currentMeshName;
       preciceData.preciceMesh = *iter;
     }
-
     // parse mode
     std::string mode = currentPreciceData.getOptionString("mode", "");
     if (mode == "read") {
@@ -249,7 +278,6 @@ void PreciceAdapterNestedSolver<FastMonodomainSolver<T1>>::
       LOG(FATAL) << currentPreciceData << "[\"mode\"] is \"" << mode << "\", "
                  << "possible values are: \"read\", \"write\".";
     }
-
     // parse variable name
     preciceData.preciceDataName =
         currentPreciceData.getOptionString("preciceDataName", "variable");
@@ -270,12 +298,31 @@ void PreciceAdapterNestedSolver<FastMonodomainSolver<T1>>::
         SlotConnectorDataHelper<SlotConnectorDataType>::nArrayItems(
             slotConnectorData,
             preciceData.slotNo); // number of fibers if there are fibers
+    LOG(INFO) << "after nArrayItems, nDofsLocalWithoutGhosts: " << nDofsLocalWithoutGhosts
+              << ", nArrayItems: " << nArrayItems;
+    nPreciceNodesFromFibers = 0;
+    for (int arrayIndex = 0; arrayIndex < nArrayItems; arrayIndex++) {
+    // get the mesh partition
+    meshPartitionBase =
+        SlotConnectorDataHelper<
+            SlotConnectorDataType>::getMeshPartitionBase(slotConnectorData,
+                                                        preciceData.slotNo,
+                                                        arrayIndex);
+    
 
-    if (nDofsLocalWithoutGhosts * nArrayItems !=
+    int nDofsLocalWithoutGhosts = meshPartitionBase->nDofsLocalWithoutGhosts();
+    nPreciceNodesFromFibers += nDofsLocalWithoutGhosts;
+    
+    }
+    
+    if (nPreciceNodesFromFibers !=
         preciceData.preciceMesh->nNodesLocal) {
       LOG(DEBUG) << ", all available slots: "
                  << SlotConnectorDataHelper<SlotConnectorDataType>::getString(
                         slotConnectorData);
+      LOG(INFO) << "After logging all available slots";
+      LOG(INFO)<< "nPreciceNodesFromFibers: " << nPreciceNodesFromFibers
+                << ", preciceMesh->nNodesLocal: " << preciceData.preciceMesh->nNodesLocal;
       LOG(FATAL)
           << currentPreciceData
           << ": Mesh does not match slot in "
@@ -311,7 +358,6 @@ void PreciceAdapterNestedSolver<FastMonodomainSolver<T1>>::
           << "  If the desired mesh is not available at the current solver, "
              "maybe insert a MapDofs class.";
     }
-
     LOG(INFO) << "Precice data \"" << preciceData.preciceDataName
               << "\" maps to "
               << (preciceData.isGeometryField ? "the geometry field of " : "")
@@ -495,21 +541,34 @@ void PreciceAdapterNestedSolver<FastMonodomainSolver<T1>>::preciceWriteData(
 
         // loop over fibers if there are any
         for (int arrayIndex = 0; arrayIndex < nArrayItems; arrayIndex++) {
-          static std::vector<double> values;
-          values.clear();
+            static std::vector<double> values;
+            values.clear();
+
+            meshPartitionBase =
+            SlotConnectorDataHelper<
+                SlotConnectorDataType>::getMeshPartitionBase(slotConnectorData,
+                                                            preciceData.slotNo,
+                                                            arrayIndex);
+        
+
+            nDofsLocalWithoutGhosts = meshPartitionBase->nDofsLocalWithoutGhosts();
           // static void slotGetValues(std::shared_ptr<SlotConnectorDataType>
           // slotConnectorData,
           //   int slotNo, int arrayIndex, const std::vector<dof_no_t>
           //   &dofNosLocal, std::vector<double> &values);
-          SlotConnectorDataHelper<SlotConnectorDataType>::slotGetValues(
-              slotConnectorData, preciceData.slotNo, arrayIndex,
-              dofNosLocalWithoutGhosts, values);
-          scalarValues_.insert(scalarValues_.end(), values.begin(),
-                               values.end());
+            dofNosLocalWithoutGhosts.resize(nDofsLocalWithoutGhosts);
+            LOG(INFO) << "Getting values for slot No " << preciceData.slotNo
+                    << ", arrayIndex " << arrayIndex
+                    << ", nDofsLocalWithoutGhosts: " << nDofsLocalWithoutGhosts << ", dofNosLocalWithoutGhosts.size(): " << dofNosLocalWithoutGhosts.size();
+            SlotConnectorDataHelper<SlotConnectorDataType>::slotGetValues(
+                slotConnectorData, preciceData.slotNo, arrayIndex,
+                dofNosLocalWithoutGhosts, values);
+            scalarValues_.insert(scalarValues_.end(), values.begin(),
+                                values.end());
 
-          LOG(DEBUG) << "arrayIndex " << arrayIndex << ", add " << values.size()
-                     << " values, now number: " << scalarValues_.size();
-        }
+            LOG(DEBUG) << "arrayIndex " << arrayIndex << ", add " << values.size()
+                        << " values, now number: " << scalarValues_.size();
+        }  
       }
 
       // scale the values by a factor given in the config
@@ -535,6 +594,13 @@ void PreciceAdapterNestedSolver<FastMonodomainSolver<T1>>::preciceWriteData(
       preciceParticipant->writeData(
           preciceData.preciceMesh->preciceMeshName, preciceData.preciceDataName,
           preciceData.preciceMesh->preciceVertexIds, scalarValues_);
+
+          LOG(INFO) << "Wrote " << scalarValues_.size() << " values to precice for data \""
+                     << preciceData.preciceDataName << "\" on mesh \""
+                     << preciceData.preciceMesh->preciceMeshName
+                     << "\" the first three values are: " << 
+                     scalarValues_[0] << ", " << scalarValues_[1] << ", " << scalarValues_[2];
+
     }
   }
   LOG(DEBUG) << "write volume data to precice complete";


### PR DESCRIPTION
## Main changes of this PR

**Issues that are addressed by this PR:**  #113 

The main problem was how the number of preCICE nodes was computed when coupling a FastMonodomainSolver (see [code]( https://github.com/opendihu/opendihu/pull/114/changes#diff-eb87f591b87138b889fcee203bf67150fdac687152cd35b5c82cda5d094b0ebdL176)):
```
preciceMesh->nNodesLocal = nDofsLocalWithoutGhosts * nArrayItems;
```
`nDofsLocalWithoutGhosts` was computed based on fiber 0. 

Now we do instead (see [code](https://github.com/opendihu/opendihu/pull/114/changes#diff-eb87f591b87138b889fcee203bf67150fdac687152cd35b5c82cda5d094b0ebdR212)):
```        
preciceMesh->nNodesLocal = nPreciceNodesFromFibers;
```
Where `nPreciceNodesFromFibers` is computed by iterating through the fibers and adding the corresponding `nDofsLocalWithoutGhosts`. 
## Additional information

**This has not been tested in parallel!!**
<!--
List known related issues, upcomming work, etc. 
-->

## Author's checklist

* [ ] I used pre-commit.
* [ ] I updated the documentation.
* [ ] I updated hard-coded version numbers. 

